### PR TITLE
add lower bound for colour

### DIFF
--- a/colouring.c
+++ b/colouring.c
@@ -17,6 +17,7 @@ int main(int argc, char const *argv[]) {
     int maxIterations = 100;
     int save = 0;   //boolean flag to save results to a csv file
     int minColour = 0;
+    int maxColour = 0;
 
     //agent colour
     int numAgents = 0;
@@ -45,6 +46,9 @@ int main(int argc, char const *argv[]) {
         }
         else if(!strcmp(argv[i], "-c")) {
             minColour = atoi(argv[i + 1]);
+        }
+        else if(!strcmp(argv[i], "-C")) {
+            maxColour = atoi(argv[i + 1]);
         }
         else if(!strcmp(argv[i], "-S")) {
             save = 1;
@@ -108,7 +112,11 @@ int main(int argc, char const *argv[]) {
 
         //colour the graph
         benchmarkMinimumGraph = minimumColour(graph, numNodes);
-        int maxColour = findNumColoursUsed(benchmarkMinimumGraph, numNodes, numNodes + 1);
+        
+        if(!maxColour) {
+            maxColour = findNumColoursUsed(benchmarkMinimumGraph, numNodes, numNodes + 1);
+        }
+
         colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, save);
 
         if(verbose) {

--- a/colouring.c
+++ b/colouring.c
@@ -16,7 +16,7 @@ int main(int argc, char const *argv[]) {
     int autoRuns = 1;
     int maxIterations = 100;
     int save = 0;   //boolean flag to save results to a csv file
-    int maxColour = 0;
+    int minColour = 0;
 
     //agent colour
     int numAgents = 0;
@@ -43,8 +43,8 @@ int main(int argc, char const *argv[]) {
         else if(!strcmp(argv[i], "-p")) {
             prob = atof(argv[i + 1]);
         }
-        else if(!strcmp(argv[i], "-C")) {
-            maxColour = atoi(argv[i + 1]) + 1;
+        else if(!strcmp(argv[i], "-c")) {
+            minColour = atoi(argv[i + 1]) + 1;
         }
         else if(!strcmp(argv[i], "-S")) {
             save = 1;
@@ -71,8 +71,8 @@ int main(int argc, char const *argv[]) {
 
     //set defaults that are based on number of nodes
 
-    if(!maxColour) {
-        maxColour = numNodes + 1;
+    if(!minColour) {
+        minColour = numNodes + 1;
     }
 
     if(!numAgents) {
@@ -107,8 +107,9 @@ int main(int argc, char const *argv[]) {
         }
 
         //colour the graph
-        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, maxColour, &minimumAgent, save);
         benchmarkMinimumGraph = minimumColour(graph, numNodes);
+        int maxColour = findNumColoursUsed(benchmarkMinimumGraph, numNodes, numNodes + 1);
+        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, save);
 
         if(verbose) {
             printGraph(colouredGraph, numNodes);

--- a/colouring.c
+++ b/colouring.c
@@ -44,7 +44,7 @@ int main(int argc, char const *argv[]) {
             prob = atof(argv[i + 1]);
         }
         else if(!strcmp(argv[i], "-c")) {
-            minColour = atoi(argv[i + 1]) + 1;
+            minColour = atoi(argv[i + 1]);
         }
         else if(!strcmp(argv[i], "-S")) {
             save = 1;

--- a/graphcolourer.h
+++ b/graphcolourer.h
@@ -70,15 +70,17 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
     return colouringGraph;
 }
 
-int colourblindFishAgent(node** fish, int numMoves, int maxColour) {
+int colourblindFishAgent(node** fishPointer, int numMoves, int maxColour) {
     int numChanges = 0;
     
-    //check for conflicts in neighbours
-    if(!(*fish)->colour || nodeIsInConflict((*fish))) {
-        (*fish)->colour = ((*fish)->colour + 1) % ((*fish)->degree + 1);
+    node* fish = *fishPointer;
 
-        if(!(*fish)->colour) {
-            (*fish)->colour++;
+    //check for conflicts in neighbours
+    if(!fish->colour || nodeIsInConflict(fish)) {
+        fish->colour = (fish->colour + 1) % (fish->degree + 1);
+
+        if(!fish->colour) {
+            fish->colour++;
         }
 
         numChanges = 1;
@@ -86,24 +88,27 @@ int colourblindFishAgent(node** fish, int numMoves, int maxColour) {
 
     //the fish wanders in its locality
     for(int m = 0; m < numMoves; m++) {
-        (*fish) = (*fish)->neighbours[rand() % (*fish)->degree];
+        *fishPointer = fish->neighbours[rand() % fish->degree];
+        fish = *fishPointer;
     }
 
     return numChanges;
 }
 
-int minimumAgent(node** agent, int numMoves, int maxColour) {
+int minimumAgent(node** agentPointer, int numMoves, int maxColour) {
     int numChanges = 0;
 
-    int* coloursInLocality = findWhichColoursInGraph((*agent)->neighbours, (*agent)->degree, maxColour);
+    node* agent = *agentPointer;
 
-    coloursInLocality[(*agent)->colour] = 1;
+    int* coloursInLocality = findWhichColoursInGraph(agent->neighbours, agent->degree, maxColour);
 
-    int max = (*agent)->colour ? (*agent)->colour : maxColour;
+    coloursInLocality[agent->colour] = 1;
+
+    int max = agent->colour ? agent->colour : maxColour;
 
     for(int c = 1; c < max; c++) {
         if(!coloursInLocality[c]) {
-            (*agent)->colour = c;
+            agent->colour = c;
             numChanges = 1;
         }
     }
@@ -112,41 +117,46 @@ int minimumAgent(node** agent, int numMoves, int maxColour) {
 
     //move the agent
     for(int m = 0; m < numMoves; m++) {
-        if((*agent)->degree == 0) {
+        if(agent->degree == 0) {
             break;  //cant move the agent; on an orphan node
         }
-        else if(findNumUncolouredNodes((*agent)->neighbours, (*agent)->degree) > 0) {
-            for(int nb = 0; nb < (*agent)->degree; nb++) {
-                if(!(*agent)->neighbours[nb]->colour) {
-                    (*agent) = (*agent)->neighbours[nb];
+        else if(findNumUncolouredNodes(agent->neighbours, agent->degree) > 0) {
+            for(int nb = 0; nb < agent->degree; nb++) {
+                if(!agent->neighbours[nb]->colour) {
+                    *agentPointer = agent->neighbours[nb];
+                    agent = *agentPointer;
                 }
             }
         }
         else {
-            node* maxColourNode = (*agent)->neighbours[0];
-            for(int nb = 0; nb < (*agent)->degree; nb++) {
-                if((*agent)->neighbours[nb]->colour > maxColourNode->colour) {
-                    maxColourNode = (*agent)->neighbours[nb];
+            node* maxColourNode = agent->neighbours[0];
+            for(int nb = 0; nb < agent->degree; nb++) {
+                if(agent->neighbours[nb]->colour > maxColourNode->colour) {
+                    maxColourNode = agent->neighbours[nb];
                 }
             }
 
-            (*agent) = maxColourNode;
+            *agentPointer = maxColourNode;
+            agent = *agentPointer;
         }
     }
 
     return numChanges;
 }
 
-int randomKernel(node** agent, int numMoves, int maxColour) {
+int randomKernel(node** agentPointer, int numMoves, int maxColour) {
     int numChanges = 0;
 
-    if(nodeIsInConflict((*agent)) || !(*agent)->colour) {
-        (*agent)->colour = rand() % maxColour + 1;
+    node* agent = *agentPointer;
+
+    if(nodeIsInConflict(agent) || !agent->colour) {
+        agent->colour = rand() % maxColour + 1;
         numChanges = 1;
     }
 
     for(int m = 0; m < numMoves; m++) {
-        (*agent) = (*agent)->neighbours[rand() % (*agent)->degree];
+        *agentPointer = agent->neighbours[rand() % agent->degree];
+        agent = *agentPointer;
     }
 
     return numChanges;

--- a/graphcolourer.h
+++ b/graphcolourer.h
@@ -5,13 +5,14 @@
 #include "graphutil.h"
 
 #define AGENT_BREAK_LIMIT 50
+#define COLOUR_INCREASE_LIMIT 20
 
 node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, int (*agentController)(node** agent, int numMoves, int numNodes), int save) {
     node** colouringGraph = copyGraph(graph, numNodes);
 
     int* problemsAtIteration = (int*)malloc(sizeof(int) * maxIterations);
 
-    int numNoChangesBreak = 0;      //if no agent makes a change in x iterations, the algorithm ends
+    int numNoChanges = 0;      //if no agent makes a change in x iterations, the algorithm ends
 
     //pick some starting nodes for the "fish"
     node** agents = fetchNUniqueNodes(colouringGraph, numNodes, numAgents);
@@ -34,18 +35,18 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
         }
 
         if(!numChanges) {
-            numNoChangesBreak++;
-            if(numNoChangesBreak == AGENT_BREAK_LIMIT && numColours >= maxColour) {
-                printf("no changes after %d iterations\n", i);
-                break;
-            }
-            else if(numNoChangesBreak == AGENT_BREAK_LIMIT) {
+            numNoChanges++;
+            if(numNoChanges == COLOUR_INCREASE_LIMIT && numColours < maxColour) {
                 numColours++;
-                numNoChangesBreak = 0;
+                numNoChanges = 0;
+            }
+            else if(numNoChanges >= AGENT_BREAK_LIMIT) {
+                printf("ran for %d iterations\n", i);
+                break;
             }
         }
         else{
-            numNoChangesBreak = 0;
+            numNoChanges = 0;
         }
     }
 

--- a/graphcolourer.h
+++ b/graphcolourer.h
@@ -6,7 +6,7 @@
 
 #define AGENT_BREAK_LIMIT 10
 
-node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int maxColour, int (*agentController)(node* agent, int numMoves, int numNodes), int save) {
+node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, int (*agentController)(node* agent, int numMoves, int numNodes), int save) {
     node** colouringGraph = copyGraph(graph, numNodes);
 
     int* problemsAtIteration = (int*)malloc(sizeof(int) * maxIterations);
@@ -16,6 +16,8 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
     //pick some starting nodes for the "fish"
     node** agents = fetchNUniqueNodes(colouringGraph, numNodes, numAgents);
 
+    int numColours = minColour;
+
     //start the iterations
     int i;
     for(i = 0; i < maxIterations; i++) {
@@ -23,7 +25,7 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
 
         //each agent makes changes to the graph
         for(int a = 0; a < numAgents; a++) {
-            numChanges += agentController(agents[a], numMoves, maxColour);
+            numChanges += agentController(agents[a], numMoves, numColours);
         }
 
         //CONSIDER: this is pretty slow; should i include this every iteration or maybe every nth iteration?
@@ -33,9 +35,13 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
 
         if(!numChanges) {
             numNoChangesBreak++;
-            if(numNoChangesBreak == AGENT_BREAK_LIMIT) {
+            if(numNoChangesBreak == AGENT_BREAK_LIMIT && numColours >= maxColour) {
                 printf("no changes after %d iterations\n", i);
                 break;
+            }
+            else if(numNoChangesBreak == AGENT_BREAK_LIMIT) {
+                numColours++;
+                numNoChangesBreak = 0;
             }
         }
         else{


### PR DESCRIPTION
the previous PR [(PR #3)](https://github.com/liamholland/fyp-code/pull/3) had some problems. the main one was that it basically went on forever. instead of that, i added a minimum colour parameter, and use the benchmark from the brute force mimimum colour as the maximum if the user does not explicitly set one, to have some limit on how long it can run for. this restricts the number of colours that can be used in the graph and effects how long the program will run for. if the max colour is set very high, the program will run for a long time without making any changes to the graph if it has already found an optimal solution.

i also fixed an issue here where i was using the value of the agents to make calculations rather than the reference (this became relevant when i created the generalised approach) but i do not think i collected many (if any) results which would have been effected by this


![](https://media1.tenor.com/m/iFg7gkWYDBEAAAAd/wojak-bug.gif)
