### PR TITLE
the first dynamic graph kernel

### DIFF
--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -13,4 +13,6 @@ int minimumAgent(node** agentPointer, int numMoves, int maxColour);
 
 int randomKernel(node** agentPointer, int numMoves, int maxColour);
 
+int edgeChopperKernel(node** agentPointer, int numMoves, int maxColour);
+
 #endif

--- a/include/graphutil.h
+++ b/include/graphutil.h
@@ -31,4 +31,6 @@ int nodeIsInConflict(node* node);
 
 int* findWhichColoursInGraph(node** graph, int numNodes, int maxColour);
 
+node** findAllConflictingNodesInGraph(node** graph, int numNodes);
+
 #endif

--- a/include/graphutil.h
+++ b/include/graphutil.h
@@ -35,4 +35,6 @@ node** findAllConflictingNodesInGraph(node** graph, int numNodes);
 
 node** findConflictingNeighboursForNode(node* n);
 
+int removeEdge(node** nodeReference, node* neighbour);
+
 #endif

--- a/include/graphutil.h
+++ b/include/graphutil.h
@@ -33,4 +33,6 @@ int* findWhichColoursInGraph(node** graph, int numNodes, int maxColour);
 
 node** findAllConflictingNodesInGraph(node** graph, int numNodes);
 
+node** findConflictingNeighboursForNode(node* n);
+
 #endif

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -187,3 +187,18 @@ int randomKernel(node** agentPointer, int numMoves, int maxColour) {
 
     return numChanges;
 }
+
+int edgeChopperKernel(node** agentPointer, int numMoves, int maxColour) {
+    int numChanges = 0;
+
+    node* agent = *agentPointer;
+
+    if(!agent->colour) {
+        agent->colour = agent->degree;
+    }
+    else if(nodeIsInConflict(agent)) {
+
+    }
+
+    return numChanges;
+}

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -194,10 +194,20 @@ int edgeChopperKernel(node** agentPointer, int numMoves, int maxColour) {
     node* agent = *agentPointer;
 
     if(!agent->colour) {
-        agent->colour = agent->degree;
+        agent->colour = agent->degree;  //something more interesting here maybe?
     }
     else if(nodeIsInConflict(agent)) {
+        node** conflicts = findConflictingNeighboursForNode(agent);
+        
+        removeEdge(agentPointer, conflicts[0]); //remove the first conflict because why not
 
+        numChanges = 1;
+    }
+
+    //move the agent
+    for(int m = 0; m < numMoves; m++) {
+        *agentPointer = agent->neighbours[rand() % agent->degree];
+        agent = *agentPointer;
     }
 
     return numChanges;

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -202,6 +202,8 @@ int edgeChopperKernel(node** agentPointer, int numMoves, int maxColour) {
         removeEdge(agentPointer, conflicts[0]); //remove the first conflict because why not
 
         numChanges = 1;
+
+        free(conflicts);
     }
 
     //move the agent

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -62,6 +62,7 @@ int freeGraph(node** graph, int numNodes) {
     for(int n = 0; n < numNodes; n++) {
         free(graph[n]->neighbours); //dont have to free each member of neighbours since they are all in this array
         free(graph[n]);
+        graph[n] == NULL;
     }
 
     free(graph);
@@ -258,20 +259,22 @@ int* findWhichColoursInGraph(node** graph, int numNodes, int maxColour) {
 node** findAllConflictingNodesInGraph(node** graph, int numNodes) {
     node** conflictingNodes = (node**)malloc(numNodes * sizeof(node*));
 
-    int numConflictingNodes = 0;
+    int totalNumConflictingNodes = 0;
 
     node** graphCopy = copyGraph(graph, numNodes);
 
     for(int i = 0; i < numNodes; i++) {
+        if(graphCopy[i] == NULL) continue;
+
         node** conflicts = findConflictingNeighboursForNode(graphCopy[i]);
         
         if(conflicts == NULL) continue;
 
         int numConflicts = sizeof(conflicts) / sizeof(node*);
 
-        memcpy(conflictingNodes, conflicts, sizeof(node*) * numConflicts);
+        memcpy(conflictingNodes[totalNumConflictingNodes], conflicts, sizeof(node*) * numConflicts);
 
-        numConflictingNodes += numConflicts;
+        totalNumConflictingNodes += numConflicts;
 
         freeGraph(conflicts, numConflicts); //this should make the pointers null in the graph copy
     }

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -301,3 +301,17 @@ node** findConflictingNeighboursForNode(node* n) {
 
     return conflictingNodes;
 }
+
+int removeEdge(node** nodeReference, node* neighbour) {
+    for(int i = 0; i < (*nodeReference)->degree; i++) {
+        if((*nodeReference)->neighbours[i] == neighbour) {
+            for(int j = i; j < (*nodeReference)->degree; j++) {
+                (*nodeReference)->neighbours[j] = (*nodeReference)->neighbours[j + 1];
+            }
+
+            return 0;
+        }
+    }
+    
+    return 1;   //did not find the neighbour
+}

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -267,7 +267,7 @@ node** findAllConflictingNodesInGraph(node** graph, int numNodes) {
         
         if(conflicts == NULL) continue;
 
-        int numConflicts = strlen(conflicts);   //pointers are a byte?
+        int numConflicts = sizeof(conflicts) / sizeof(node*);
 
         memcpy(conflictingNodes, conflicts, sizeof(node*) * numConflicts);
 
@@ -297,9 +297,7 @@ node** findConflictingNeighboursForNode(node* n) {
         return NULL;
     }
 
-    realloc(conflictingNodes, numConflictingNodes * sizeof(numConflictingNodes));
-
-    return conflictingNodes;
+    return (node**)realloc(conflictingNodes, numConflictingNodes * sizeof(numConflictingNodes));
 }
 
 int removeEdge(node** nodeReference, node* neighbour) {
@@ -310,7 +308,7 @@ int removeEdge(node** nodeReference, node* neighbour) {
             }
 
             (*nodeReference)->neighbours[(*nodeReference)->degree - 1] = NULL;
-            realloc((*nodeReference)->neighbours, sizeof(node*) * ((*nodeReference)->degree - 1));
+            (*nodeReference)->neighbours = (node**)realloc((*nodeReference)->neighbours, sizeof(node*) * ((*nodeReference)->degree - 1));
             (*nodeReference)->degree--;
 
             return 0;

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -254,3 +254,35 @@ int* findWhichColoursInGraph(node** graph, int numNodes, int maxColour) {
 
     return colourTruthVector;
 }
+
+node** findAllConflictingNodesInGraph(node** graph, int numNodes) {
+    node** conflictingNodes = (node**)malloc(numNodes * sizeof(node*));
+
+    int numConflictingNodes = 0;
+
+    node** graphCopy = copyGraph(graph, numNodes);
+
+    for(int i = 0; i < numNodes; i++) {
+        if(nodeIsInConflict(graph[i])) {
+            conflictingNodes[numConflictingNodes++] = graph[i];
+            //delete node and conflicting neighbours from the graph copy
+        }
+    }
+
+    freeGraph(graphCopy, numNodes);
+
+    return conflictingNodes;
+}
+
+node** findConflictingNeighbours(node* n) {
+    node** conflictingNodes = (node**)malloc((n->degree + 1) * sizeof(node*));
+
+    int numConflictingNodes = 0;
+
+    for(int i = 0; i < n->degree; i++) {
+        if(n->colour == n->neighbours[i]->colour) {
+            conflictingNodes[numConflictingNodes] = (node*)malloc(sizeof(node));
+            memcpy(conflictingNodes[numConflictingNodes], n->neighbours[i], sizeof(node));
+        }
+    }
+}

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -309,6 +309,10 @@ int removeEdge(node** nodeReference, node* neighbour) {
                 (*nodeReference)->neighbours[j] = (*nodeReference)->neighbours[j + 1];
             }
 
+            (*nodeReference)->neighbours[(*nodeReference)->degree - 1] = NULL;
+            realloc((*nodeReference)->neighbours, sizeof(node*) * ((*nodeReference)->degree - 1));
+            (*nodeReference)->degree--;
+
             return 0;
         }
     }

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -263,10 +263,17 @@ node** findAllConflictingNodesInGraph(node** graph, int numNodes) {
     node** graphCopy = copyGraph(graph, numNodes);
 
     for(int i = 0; i < numNodes; i++) {
-        if(nodeIsInConflict(graph[i])) {
-            conflictingNodes[numConflictingNodes++] = graph[i];
-            //delete node and conflicting neighbours from the graph copy
-        }
+        node** conflicts = findConflictingNeighboursForNode(graphCopy[i]);
+        
+        if(conflicts == NULL) continue;
+
+        int numConflicts = strlen(conflicts);   //pointers are a byte?
+
+        memcpy(conflictingNodes, conflicts, sizeof(node*) * numConflicts);
+
+        numConflictingNodes += numConflicts;
+
+        freeGraph(conflicts, numConflicts); //this should make the pointers null in the graph copy
     }
 
     freeGraph(graphCopy, numNodes);
@@ -274,15 +281,23 @@ node** findAllConflictingNodesInGraph(node** graph, int numNodes) {
     return conflictingNodes;
 }
 
-node** findConflictingNeighbours(node* n) {
-    node** conflictingNodes = (node**)malloc((n->degree + 1) * sizeof(node*));
+node** findConflictingNeighboursForNode(node* n) {
+    node** conflictingNodes = (node**)malloc(n->degree * sizeof(node*));
 
     int numConflictingNodes = 0;
 
     for(int i = 0; i < n->degree; i++) {
         if(n->colour == n->neighbours[i]->colour) {
-            conflictingNodes[numConflictingNodes] = (node*)malloc(sizeof(node));
-            memcpy(conflictingNodes[numConflictingNodes], n->neighbours[i], sizeof(node));
+            conflictingNodes[numConflictingNodes++] = n->neighbours[i];
         }
     }
+
+    if(numConflictingNodes == 0) {
+        free(conflictingNodes);
+        return NULL;
+    }
+
+    realloc(conflictingNodes, numConflictingNodes * sizeof(numConflictingNodes));
+
+    return conflictingNodes;
 }


### PR DESCRIPTION
this change adds the first dynamic graph kernel, a primitive function called `edgeChopperKernel`. its function is very simple:
- if a node is uncoloured, colour it with its degree
- if a node is in conflict, remove a conflicting edge (it just removes the first one it finds

the idea is that it just removes all of the conflicts rather than changing the colours. this is not very useful in practice, but it does produce solutions very quickly. you can see how many edges were removed by comparing the colour to the degree (they could have been removed by a different node, but practically it is the same thing). the utility functions are the most important part of this PR, since they actually allow for dynamic changes as well as identifying specific conflicts.


![](https://media1.tenor.com/m/UXORndNhXeoAAAAd/the-simpsons-homer.gif)
