### PR TITLE
dynamic kernels

### DIFF
--- a/include/dynamicKernels.h
+++ b/include/dynamicKernels.h
@@ -1,0 +1,8 @@
+#ifndef DYNAMIC
+#define DYNAMIC
+
+#include "node.h"
+
+int possiblyRemoveEdgeKernel(node* agent);
+
+#endif

--- a/include/dynamicKernels.h
+++ b/include/dynamicKernels.h
@@ -3,7 +3,7 @@
 
 #include "node.h"
 
-int possiblyRemoveEdgeKernel(node*** graphReference, int numNodes, node* agent);
+int possiblyRemoveEdgeKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents);
 
 int possiblyRemoveNodeKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents);
 

--- a/include/dynamicKernels.h
+++ b/include/dynamicKernels.h
@@ -3,10 +3,8 @@
 
 #include "node.h"
 
-int possiblyRemoveEdgeKernel(node** graph, int numNodes, node* agent);
+int possiblyRemoveEdgeKernel(node*** graphReference, int numNodes, node* agent);
 
-int possiblyRemoveNodeKernel(node** graph, int numNodes, node* agent);
-
-int doubleGraphSizeKernel(node** graph, int numNodes, node* agent);
+int possiblyRemoveNodeKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents);
 
 #endif

--- a/include/dynamicKernels.h
+++ b/include/dynamicKernels.h
@@ -3,10 +3,10 @@
 
 #include "node.h"
 
-int possiblyRemoveEdgeKernel(node** graph, node* agent);
+int possiblyRemoveEdgeKernel(node** graph, int numNodes, node* agent);
 
-int possiblyRemoveNodeKernel(node** graph, node* agent);
+int possiblyRemoveNodeKernel(node** graph, int numNodes, node* agent);
 
-int doubleGraphSizeKernel(node** graph, node* agent);
+int doubleGraphSizeKernel(node** graph, int numNodes, node* agent);
 
 #endif

--- a/include/dynamicKernels.h
+++ b/include/dynamicKernels.h
@@ -5,7 +5,7 @@
 
 int possiblyRemoveEdgeKernel(node** graph, node* agent);
 
-int possiblyRemoveNodeKernel(node**, node* agent);
+int possiblyRemoveNodeKernel(node** graph, node* agent);
 
 int doubleGraphSizeKernel(node** graph, node* agent);
 

--- a/include/dynamicKernels.h
+++ b/include/dynamicKernels.h
@@ -3,6 +3,10 @@
 
 #include "node.h"
 
-int possiblyRemoveEdgeKernel(node* agent);
+int possiblyRemoveEdgeKernel(node** graph, node* agent);
+
+int possiblyRemoveNodeKernel(node**, node* agent);
+
+int doubleGraphSizeKernel(node** graph, node* agent);
 
 #endif

--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -3,7 +3,8 @@
 
 #include "node.h"
 
-node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, int (*agentController)(node** agent, int numMoves, int numNodes), int save);
+node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, 
+    int maxColour, int (*agentController)(node** agent, int numMoves, int numNodes), int (*dynamicKernel)(node** agent), int save);
 
 int colourblindFishAgentIncrement(node** fishPointer, int numMoves, int maxColour);
 

--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -3,8 +3,8 @@
 
 #include "node.h"
 
-node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, 
-    int maxColour, int (*agentController)(node** agent, int numMoves, int numNodes), int (*dynamicKernel)(node** graph, node* agent), int save);
+node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, 
+    int (*agentController)(node** agent, int numMoves, int numNodes), int (*dynamicKernel)(node** graph, int numNodes, node* agent), int save);
 
 int colourblindFishAgentIncrement(node** fishPointer, int numMoves, int maxColour);
 

--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -4,7 +4,7 @@
 #include "node.h"
 
 node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, 
-    int maxColour, int (*agentController)(node** agent, int numMoves, int numNodes), int (*dynamicKernel)(node** agent), int save);
+    int maxColour, int (*agentController)(node** agent, int numMoves, int numNodes), int (*dynamicKernel)(node** graph, node* agent), int save);
 
 int colourblindFishAgentIncrement(node** fishPointer, int numMoves, int maxColour);
 

--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -4,7 +4,8 @@
 #include "node.h"
 
 node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, 
-    int (*agentController)(node** agent, int numMoves, int numNodes), int (*dynamicKernel)(node** graph, int numNodes, node* agent), int save);
+    int (*agentController)(node** agent, int numMoves, int numNodes),
+    int (*dynamicKernel)(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents), int save);
 
 int colourblindFishAgentIncrement(node** fishPointer, int numMoves, int maxColour);
 

--- a/include/graphutil.h
+++ b/include/graphutil.h
@@ -76,6 +76,16 @@ node** findConflictingNeighboursForNode(node* n);
 //and its neighbour
 int removeEdge(node* nodeReference, node* neighbour);
 
+//removes edges between the target node and all of its neighbours
+//basically a convenience function; the amount of reallocation going
+//on here guarantees that it is not optimal
+int makeNodeOrpan(node* targetNode);
+
+//yes that really is a `node***`
+//removes the node and frees all of its memory, then reallocates the memory
+//associated with the array, hence the pass by reference for the pointer
+int removeNode(node*** graphReference, int numNodes, node* targetNode);
+
 //this function will return a pointer to the node with the highest degree
 //in the case of a tie, the contender with the "largest colour" (least optimised)
 //will be returned 

--- a/include/graphutil.h
+++ b/include/graphutil.h
@@ -45,8 +45,7 @@ int findNumConflicts(node** graph, int numNodes);
 int findNumUncolouredNodes(node** graph, int numNodes);
 
 //picks n unique nodes from the graph
-//an n greater than or equal to the number of nodes will return
-//the pointer to the full graph
+//n is capped to the size of the graph (numNodes)
 node** fetchNUniqueNodes(node** fullGraph, int numNodes, int n);
 
 //appends an array of number of conflicts at iteration i to a csv file

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -136,6 +136,9 @@ int main(int argc, char const *argv[]) {
 
         colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, agentController, dynamicKernel, save);
 
+        //measure the graph after colouring
+        numNodes = sizeof(colouredGraph) / sizeof(node*);
+
         if(verbose) {
             autoRuns = 1;   //should only run once if viewing the graph
 

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -130,7 +130,7 @@ int main(int argc, char const *argv[]) {
             maxColour = findNumColoursUsed(benchmarkMinimumGraph, numNodes, numNodes + 1);
         }
 
-        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, &possiblyRemoveEdgeKernel, save);
+        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, &possiblyRemoveNodeKernel, save);
 
         if(verbose) {
             autoRuns = 1;   //should only run once if viewing the graph
@@ -142,7 +142,7 @@ int main(int argc, char const *argv[]) {
             printTraversalModeCommands();
             while(traverseGraph(colouredGraph, numNodes, highestDegreeNode, 1) < 0) {
                 //run it again
-                colouredGraph = agentColour(colouredGraph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, &possiblyRemoveEdgeKernel, save);
+                colouredGraph = agentColour(colouredGraph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, &possiblyRemoveNodeKernel, save);
             }
         }
 

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -125,7 +125,7 @@ int main(int argc, char const *argv[]) {
 
 
         int (*agentController) (node**, int, int) = &minimumAgent;
-        int (*dynamicKernel) (node***, int*, node*, node***, int*) = &possiblyRemoveEdgeKernel;
+        int (*dynamicKernel) (node***, int*, node*, node***, int*) = &possiblyRemoveNodeKernel;
 
         //colour the graph
         benchmarkMinimumGraph = minimumColour(graph, numNodes);

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -130,7 +130,7 @@ int main(int argc, char const *argv[]) {
             maxColour = findNumColoursUsed(benchmarkMinimumGraph, numNodes, numNodes + 1);
         }
 
-        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, &doubleGraphSizeKernel, save);
+        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, &possiblyRemoveEdgeKernel, save);
 
         if(verbose) {
             autoRuns = 1;   //should only run once if viewing the graph
@@ -142,7 +142,7 @@ int main(int argc, char const *argv[]) {
             printTraversalModeCommands();
             while(traverseGraph(colouredGraph, numNodes, highestDegreeNode, 1) < 0) {
                 //run it again
-                colouredGraph = agentColour(colouredGraph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, &doubleGraphSizeKernel, save);
+                colouredGraph = agentColour(colouredGraph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, &possiblyRemoveEdgeKernel, save);
             }
         }
 

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -129,7 +129,7 @@ int main(int argc, char const *argv[]) {
             maxColour = findNumColoursUsed(benchmarkMinimumGraph, numNodes, numNodes + 1);
         }
 
-        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, save);
+        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, NULL, save);
 
         if(verbose) {
             autoRuns = 1;   //should only run once if viewing the graph
@@ -141,7 +141,7 @@ int main(int argc, char const *argv[]) {
             printTraversalModeCommands();
             while(traverseGraph(colouredGraph, numNodes, highestDegreeNode, 1) < 0) {
                 //run it again
-                colouredGraph = agentColour(colouredGraph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, save);
+                colouredGraph = agentColour(colouredGraph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, NULL, save);
             }
         }
 

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -8,6 +8,7 @@
 #include "centralisedgraphcolouring.h"
 #include "graphutil.h"
 #include "visualisation.h"
+#include "dynamicKernels.h"
 
 #define HELP_FILE_NAME "help.txt"
 
@@ -129,7 +130,7 @@ int main(int argc, char const *argv[]) {
             maxColour = findNumColoursUsed(benchmarkMinimumGraph, numNodes, numNodes + 1);
         }
 
-        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, NULL, save);
+        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, &doubleGraphSizeKernel, save);
 
         if(verbose) {
             autoRuns = 1;   //should only run once if viewing the graph
@@ -141,7 +142,7 @@ int main(int argc, char const *argv[]) {
             printTraversalModeCommands();
             while(traverseGraph(colouredGraph, numNodes, highestDegreeNode, 1) < 0) {
                 //run it again
-                colouredGraph = agentColour(colouredGraph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, NULL, save);
+                colouredGraph = agentColour(colouredGraph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, &doubleGraphSizeKernel, save);
             }
         }
 

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -123,6 +123,10 @@ int main(int argc, char const *argv[]) {
                 return 1;
         }
 
+
+        int (*agentController) (node**, int, int) = &minimumAgent;
+        int (*dynamicKernel) (node***, int*, node*, node***, int*) = &possiblyRemoveEdgeKernel;
+
         //colour the graph
         benchmarkMinimumGraph = minimumColour(graph, numNodes);
         
@@ -130,7 +134,7 @@ int main(int argc, char const *argv[]) {
             maxColour = findNumColoursUsed(benchmarkMinimumGraph, numNodes, numNodes + 1);
         }
 
-        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, &possiblyRemoveNodeKernel, save);
+        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, agentController, dynamicKernel, save);
 
         if(verbose) {
             autoRuns = 1;   //should only run once if viewing the graph
@@ -142,7 +146,7 @@ int main(int argc, char const *argv[]) {
             printTraversalModeCommands();
             while(traverseGraph(colouredGraph, numNodes, highestDegreeNode, 1) < 0) {
                 //run it again
-                colouredGraph = agentColour(colouredGraph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, &minimumAgent, &possiblyRemoveNodeKernel, save);
+                colouredGraph = agentColour(colouredGraph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, agentController, dynamicKernel, save);
             }
         }
 

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -13,8 +13,6 @@ int possiblyRemoveEdgeKernel(node*** graphReference, int* numNodes, node* agent,
 
 int possiblyRemoveNodeKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents) {
     if(rand() % 1000 == 0) {
-        removeNode(graphReference, *numNodes, agent);
-
         node** graph = *graphReference;
         node** agents = *agentsReference;
 
@@ -22,14 +20,19 @@ int possiblyRemoveNodeKernel(node*** graphReference, int* numNodes, node* agent,
         if(graph != agents) {
             for(int i = 0; i < *numAgents; i++) {
                 if(agents[i] == agent) {
-                    for(int j = i; j < *numAgents - 1; j++) {
+                    for(int j = i; j < (*numAgents - 1); j++) {
                         agents[j] = agents[j + 1];
                     }
 
-                    (*agentsReference) = (node**)realloc(*agentsReference, sizeof(node*) * (*numAgents - 1));
+                    agents[*numAgents - 1] = NULL;
+                    *agentsReference = (node**)realloc(*agentsReference, sizeof(node*) * (*numAgents - 1));
+
+                    break;
                 }
             }
         }
+
+        removeNode(graphReference, *numNodes, agent);
 
         *numNodes = *numNodes - 1;
         *numAgents = *numAgents - 1;

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -17,28 +17,21 @@ int possiblyRemoveNodeKernel(node*** graphReference, int* numNodes, node* agent,
         node** agents = *agentsReference;
 
         //remove the pointer from the agents array if necessary
-        if(*graphReference != agents) {
-            removeNode(graphReference, *numNodes, agent);
+        removeNode(graphReference, *numNodes, agent);
 
-            //multiple agents may have moved onto the node
-            int countValidAgents = 0;
-            node** remainingAgents = (node**)malloc(sizeof(node*) * (*numAgents));
-            for(int a = 0; a < *numAgents; a++) {
-                if(agents[a] != agent) {
-                    remainingAgents[countValidAgents++] = agents[a];
-                }
+        //multiple agents may have moved onto the node
+        int countValidAgents = 0;
+        node** remainingAgents = (node**)malloc(sizeof(node*) * (*numAgents));
+        for(int a = 0; a < *numAgents; a++) {
+            if(agents[a] != agent) {
+                remainingAgents[countValidAgents++] = agents[a];
             }
+        }
 
-            remainingAgents = (node**)realloc(remainingAgents, sizeof(node*) * countValidAgents);
-            free(agents);
-            *agentsReference = remainingAgents;
-            *numAgents = countValidAgents;
-        }
-        else {
-            removeNode(graphReference, *numNodes, agent);
-            *agentsReference = *graphReference;
-            *numAgents -= 1;    //will only remove 1 agent in this case
-        }
+        remainingAgents = (node**)realloc(remainingAgents, sizeof(node*) * countValidAgents);
+        free(agents);
+        *agentsReference = remainingAgents;
+        *numAgents = countValidAgents;
 
         //will only ever remove one node at a time
         *numNodes -= 1;

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include "graphutil.h"
 #include "dynamicKernels.h"
 
@@ -10,18 +11,33 @@ int possiblyRemoveEdgeKernel(node** graph, node* agent) {
     return 0;
 }
 
-int possiblyRemoveNodeKernel(node**, node* agent) {
+int possiblyRemoveNodeKernel(node** graph, node* agent) {
     if(rand() % 100 == 0) {
-        //remove the node outright
+        removeNode(&graph, sizeof(graph) / sizeof(node*), agent);
     }
-    
+
     return 0;
 }
 
+int doubled = 0;
+
 int doubleGraphSizeKernel(node** graph, node* agent) {
-    node** secondGraph = copyGraph(graph, sizeof(graph) / sizeof(node*));
+    int numNodes = sizeof(graph) / sizeof(node*);
+    if(!doubled && rand() % 1000 == 0) {
+        node** secondGraph = copyGraph(graph, numNodes);
 
-    addEdgeBetweenNodes(graph[0], secondGraph[0]);
+        //modify the new node ids
+        for(int n = 0; n < numNodes; n++) {
+            secondGraph[n]->id += numNodes;
+        }
 
-    return 0;
+        addEdgeBetweenNodes(graph[0], secondGraph[0]);
+
+        doubled = 1;
+        numNodes *= 2;
+
+        printf("made dynamic change\n");
+    }
+
+    return numNodes;
 }

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -13,9 +13,7 @@ int possiblyRemoveEdgeKernel(node** graph, int numNodes, node* agent) {
 
 int possiblyRemoveNodeKernel(node** graph, int numNodes, node* agent) {
     if(rand() % 1000 == 0) {
-        printf("removing node %d\n", agent->id);
         removeNode(&graph, numNodes, agent);
-        printf("removed node\n");
         return -1;
     }
 

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -3,7 +3,7 @@
 #include "graphutil.h"
 #include "dynamicKernels.h"
 
-int possiblyRemoveEdgeKernel(node** graph, int numNodes, node* agent) {
+int possiblyRemoveEdgeKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents) {
     if(agent->degree > 0 && rand() % 1000 == 0) {
         removeEdge(agent, agent->neighbours[rand() % agent->degree]);
     }
@@ -11,32 +11,30 @@ int possiblyRemoveEdgeKernel(node** graph, int numNodes, node* agent) {
     return 0;
 }
 
-int possiblyRemoveNodeKernel(node** graph, int numNodes, node* agent) {
+int possiblyRemoveNodeKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents) {
     if(rand() % 1000 == 0) {
-        removeNode(&graph, numNodes, agent);
-        return -1;
-    }
+        removeNode(graphReference, *numNodes, agent);
 
-    return 0;
-}
+        node** graph = *graphReference;
+        node** agents = *agentsReference;
 
-int doubled = 0;
+        //remove the pointer from the agents array if necessary
+        if(graph != agents) {
+            for(int i = 0; i < *numAgents; i++) {
+                if(agents[i] == agent) {
+                    for(int j = i; j < *numAgents - 1; j++) {
+                        agents[j] = agents[j + 1];
+                    }
 
-int doubleGraphSizeKernel(node** graph, int numNodes, node* agent) {
-    if(!doubled && rand() % 1000 == 0) {
-        node** secondGraph = copyGraph(graph, numNodes);
-
-        //modify the new node ids
-        for(int n = 0; n < numNodes; n++) {
-            secondGraph[n]->id += numNodes;
+                    (*agentsReference) = (node**)realloc(*agentsReference, sizeof(node*) * (*numAgents - 1));
+                }
+            }
         }
 
-        addEdgeBetweenNodes(graph[0], secondGraph[0]);
-
-        doubled = 1;
-
-        return numNodes;
+        *numNodes = *numNodes - 1;
+        *numAgents = *numAgents - 1;
     }
+
 
     return 0;
 }

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -13,31 +13,36 @@ int possiblyRemoveEdgeKernel(node*** graphReference, int* numNodes, node* agent,
 
 int possiblyRemoveNodeKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents) {
     if(rand() % 1000 == 0) {
-        node** graph = *graphReference;
+
         node** agents = *agentsReference;
 
         //remove the pointer from the agents array if necessary
-        if(graph != agents) {
-            for(int i = 0; i < *numAgents; i++) {
-                if(agents[i] == agent) {
-                    for(int j = i; j < (*numAgents - 1); j++) {
-                        agents[j] = agents[j + 1];
-                    }
+        if(*graphReference != agents) {
+            removeNode(graphReference, *numNodes, agent);
 
-                    agents[*numAgents - 1] = NULL;
-                    *agentsReference = (node**)realloc(*agentsReference, sizeof(node*) * (*numAgents - 1));
-
-                    break;
+            //multiple agents may have moved onto the node
+            int countValidAgents = 0;
+            node** remainingAgents = (node**)malloc(sizeof(node*) * (*numAgents));
+            for(int a = 0; a < *numAgents; a++) {
+                if(agents[a] != agent) {
+                    remainingAgents[countValidAgents++] = agents[a];
                 }
             }
+
+            remainingAgents = (node**)realloc(remainingAgents, sizeof(node*) * countValidAgents);
+            free(agents);
+            *agentsReference = remainingAgents;
+            *numAgents = countValidAgents;
+        }
+        else {
+            removeNode(graphReference, *numNodes, agent);
+            *agentsReference = *graphReference;
+            *numAgents -= 1;    //will only remove 1 agent in this case
         }
 
-        removeNode(graphReference, *numNodes, agent);
-
-        *numNodes = *numNodes - 1;
-        *numAgents = *numAgents - 1;
+        //will only ever remove one node at a time
+        *numNodes -= 1;
     }
-
 
     return 0;
 }

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -6,7 +6,6 @@
 int possiblyRemoveEdgeKernel(node** graph, int numNodes, node* agent) {
     if(agent->degree > 0 && rand() % 1000 == 0) {
         removeEdge(agent, agent->neighbours[rand() % agent->degree]);
-        printf("removed edge from agent %d\n", agent->id);
     }
 
     return numNodes;

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -8,15 +8,18 @@ int possiblyRemoveEdgeKernel(node** graph, int numNodes, node* agent) {
         removeEdge(agent, agent->neighbours[rand() % agent->degree]);
     }
 
-    return numNodes;
+    return 0;
 }
 
 int possiblyRemoveNodeKernel(node** graph, int numNodes, node* agent) {
-    if(rand() % 100 == 0) {
-        removeNode(&graph, sizeof(graph) / sizeof(node*), agent);
+    if(rand() % 1000 == 0) {
+        printf("removing node %d\n", agent->id);
+        removeNode(&graph, numNodes, agent);
+        printf("removed node\n");
+        return -1;
     }
 
-    return numNodes;
+    return 0;
 }
 
 int doubled = 0;
@@ -33,10 +36,9 @@ int doubleGraphSizeKernel(node** graph, int numNodes, node* agent) {
         addEdgeBetweenNodes(graph[0], secondGraph[0]);
 
         doubled = 1;
-        numNodes *= 2;
 
-        printf("made dynamic change\n");
+        return numNodes;
     }
 
-    return numNodes;
+    return 0;
 }

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -3,26 +3,26 @@
 #include "graphutil.h"
 #include "dynamicKernels.h"
 
-int possiblyRemoveEdgeKernel(node** graph, node* agent) {
-    if(agent->degree > 0 && rand() % 10 == 0) {
+int possiblyRemoveEdgeKernel(node** graph, int numNodes, node* agent) {
+    if(agent->degree > 0 && rand() % 1000 == 0) {
         removeEdge(agent, agent->neighbours[rand() % agent->degree]);
+        printf("removed edge from agent %d\n", agent->id);
     }
 
-    return 0;
+    return numNodes;
 }
 
-int possiblyRemoveNodeKernel(node** graph, node* agent) {
+int possiblyRemoveNodeKernel(node** graph, int numNodes, node* agent) {
     if(rand() % 100 == 0) {
         removeNode(&graph, sizeof(graph) / sizeof(node*), agent);
     }
 
-    return 0;
+    return numNodes;
 }
 
 int doubled = 0;
 
-int doubleGraphSizeKernel(node** graph, node* agent) {
-    int numNodes = sizeof(graph) / sizeof(node*);
+int doubleGraphSizeKernel(node** graph, int numNodes, node* agent) {
     if(!doubled && rand() % 1000 == 0) {
         node** secondGraph = copyGraph(graph, numNodes);
 

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -1,0 +1,11 @@
+#include <stdlib.h>
+#include "graphutil.h"
+#include "dynamicKernels.h"
+
+int possiblyRemoveEdgeKernel(node* agent) {
+    if(agent->degree > 0 && rand() % 10 == 0) {
+        removeEdge(agent, agent->neighbours[rand() % agent->degree]);
+    }
+
+    return 0;
+}

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -18,10 +18,10 @@ int possiblyRemoveNodeKernel(node**, node* agent) {
     return 0;
 }
 
-int duplicateTheGraph(node** graph, node* agent) {
+int doubleGraphSizeKernel(node** graph, node* agent) {
     node** secondGraph = copyGraph(graph, sizeof(graph) / sizeof(node*));
 
-    //connect the graphs together in some way
+    addEdgeBetweenNodes(graph[0], secondGraph[0]);
 
     return 0;
 }

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -2,10 +2,26 @@
 #include "graphutil.h"
 #include "dynamicKernels.h"
 
-int possiblyRemoveEdgeKernel(node* agent) {
+int possiblyRemoveEdgeKernel(node** graph, node* agent) {
     if(agent->degree > 0 && rand() % 10 == 0) {
         removeEdge(agent, agent->neighbours[rand() % agent->degree]);
     }
+
+    return 0;
+}
+
+int possiblyRemoveNodeKernel(node**, node* agent) {
+    if(rand() % 100 == 0) {
+        //remove the node outright
+    }
+    
+    return 0;
+}
+
+int duplicateTheGraph(node** graph, node* agent) {
+    node** secondGraph = copyGraph(graph, sizeof(graph) / sizeof(node*));
+
+    //connect the graphs together in some way
 
     return 0;
 }

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -8,7 +8,7 @@
 #define COLOUR_INCREASE_LIMIT 2
 
 node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, 
-    int (*agentController)(node** agent, int numMoves, int numNodes), int (*dynamicKernel)(node** graph, int numNodes, node* agent), int save)
+    int (*agentController)(node**, int, int), int (*dynamicKernel)(node***, int*, node*, node***, int*), int save)
 {
     node** colouringGraph = copyGraph(graph, numNodes);
 
@@ -30,9 +30,7 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
         for(int a = 0; a < numAgents; a++) {
             numChanges += agentController(&agents[a], numMoves, numColours);
             if(dynamicKernel != NULL) {
-                int diff = dynamicKernel(agents, numAgents, agents[a]);
-                numAgents += diff;
-                numNodes += diff;
+                dynamicKernel(&colouringGraph, &numNodes, agents[a], &agents, &numAgents);
             }
         }
 
@@ -56,6 +54,8 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
             numNoChanges = 0;
         }
     }
+
+    printf("done\n");
 
     printf("number of agents: %d; number of colours: %d; number of conflicts: %d; number of missed nodes: %d\n", 
         numAgents, findNumColoursUsed(colouringGraph, numNodes, numNodes), findNumConflicts(colouringGraph, numNodes), findNumUncolouredNodes(colouringGraph, numNodes));

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -7,7 +7,8 @@
 #define AGENT_BREAK_LIMIT 10
 #define COLOUR_INCREASE_LIMIT 2
 
-node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, int (*agentController)(node** agent, int numMoves, int numNodes), int save) {
+node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, 
+    int maxColour, int (*agentController)(node** agent, int numMoves, int numNodes), int (*dynamicKernel)(node** agent), int save) {
     node** colouringGraph = copyGraph(graph, numNodes);
 
     int* problemsAtIteration = (int*)malloc(sizeof(int) * maxIterations);
@@ -27,6 +28,9 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
         //each agent makes changes to the graph
         for(int a = 0; a < numAgents; a++) {
             numChanges += agentController(&agents[a], numMoves, numColours);
+            if(dynamicKernel != NULL) {
+                dynamicKernel(agents[a]);
+            }
         }
 
         //CONSIDER: this is pretty slow; should i include this every iteration or maybe every nth iteration?

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -1,6 +1,7 @@
 #include <time.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "graphcolourer.h"
 #include "graphutil.h"
 
@@ -26,13 +27,19 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
     for(i = 0; i < maxIterations; i++) {
         int numChanges = 0;
 
+        node** agentsCopy = (node**)malloc(sizeof(node*) * numAgents);
+        memcpy(agentsCopy, agents, sizeof(node*) * numAgents);
+
         //each agent makes changes to the graph
         for(int a = 0; a < numAgents; a++) {
             numChanges += agentController(&agents[a], numMoves, numColours);
             if(dynamicKernel != NULL) {
-                dynamicKernel(&colouringGraph, &numNodes, agents[a], &agents, &numAgents);
+                dynamicKernel(&colouringGraph, &numNodes, agents[a], &agentsCopy, &numAgents);
             }
         }
+
+        free(agents);
+        agents = agentsCopy;
 
         //CONSIDER: this is pretty slow; should i include this every iteration or maybe every nth iteration?
         if(save) {
@@ -54,8 +61,6 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
             numNoChanges = 0;
         }
     }
-
-    printf("done\n");
 
     printf("number of agents: %d; number of colours: %d; number of conflicts: %d; number of missed nodes: %d\n", 
         numAgents, findNumColoursUsed(colouringGraph, numNodes, numNodes), findNumConflicts(colouringGraph, numNodes), findNumUncolouredNodes(colouringGraph, numNodes));

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -7,8 +7,9 @@
 #define AGENT_BREAK_LIMIT 10
 #define COLOUR_INCREASE_LIMIT 2
 
-node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, 
-    int maxColour, int (*agentController)(node** agent, int numMoves, int numNodes), int (*dynamicKernel)(node** graph, node* agent), int save) {
+node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, 
+    int (*agentController)(node** agent, int numMoves, int numNodes), int (*dynamicKernel)(node** graph, int numNodes, node* agent), int save)
+{
     node** colouringGraph = copyGraph(graph, numNodes);
 
     int* problemsAtIteration = (int*)malloc(sizeof(int) * maxIterations);

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -8,7 +8,7 @@
 #define COLOUR_INCREASE_LIMIT 2
 
 node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, 
-    int maxColour, int (*agentController)(node** agent, int numMoves, int numNodes), int (*dynamicKernel)(node** agent), int save) {
+    int maxColour, int (*agentController)(node** agent, int numMoves, int numNodes), int (*dynamicKernel)(node** graph, node* agent), int save) {
     node** colouringGraph = copyGraph(graph, numNodes);
 
     int* problemsAtIteration = (int*)malloc(sizeof(int) * maxIterations);
@@ -29,9 +29,11 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
         for(int a = 0; a < numAgents; a++) {
             numChanges += agentController(&agents[a], numMoves, numColours);
             if(dynamicKernel != NULL) {
-                dynamicKernel(agents[a]);
+                numNodes = dynamicKernel(colouringGraph, agents[a]);
             }
         }
+
+        printf("completed agent iterations\n");
 
         //CONSIDER: this is pretty slow; should i include this every iteration or maybe every nth iteration?
         if(save) {

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -29,11 +29,9 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
         for(int a = 0; a < numAgents; a++) {
             numChanges += agentController(&agents[a], numMoves, numColours);
             if(dynamicKernel != NULL) {
-                numNodes = dynamicKernel(colouringGraph, agents[a]);
+                numNodes = dynamicKernel(colouringGraph, numNodes, agents[a]);
             }
         }
-
-        printf("completed agent iterations\n");
 
         //CONSIDER: this is pretty slow; should i include this every iteration or maybe every nth iteration?
         if(save) {

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -68,14 +68,7 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
     }
 
     free(problemsAtIteration);
-
-    //TODO: update fetchNUnique Nodes
-    //this "if" is here because freeing this pointer breaks the code if the pointer is the same as the original graph pointer
-    //the pointers are the same if numNodes >= numAgents (see graphutil.h -> fetchNUniqueNodes)
-    //need to copy the pointer instead or just embrace the unoptimal solution
-    if(numAgents < numNodes) {
-        free(agents);
-    }
+    free(agents);
 
     return colouringGraph;
 }

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -16,7 +16,7 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
 
     int numNoChanges = 0;      //if no agent makes a change in x iterations, the algorithm ends
 
-    //pick some starting nodes for the "fish"
+    //pick some starting nodes for the agents
     node** agents = fetchNUniqueNodes(colouringGraph, numNodes, numAgents);
 
     int numColours = minColour;
@@ -30,7 +30,9 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
         for(int a = 0; a < numAgents; a++) {
             numChanges += agentController(&agents[a], numMoves, numColours);
             if(dynamicKernel != NULL) {
-                numNodes = dynamicKernel(colouringGraph, numNodes, agents[a]);
+                int diff = dynamicKernel(agents, numAgents, agents[a]);
+                numAgents += diff;
+                numNodes += diff;
             }
         }
 

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -20,6 +20,10 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
     //pick some starting nodes for the agents
     node** agents = fetchNUniqueNodes(colouringGraph, numNodes, numAgents);
 
+    for(int a = 0; a < numAgents; a++) {
+        printf("%d\n", agents[a]->id);
+    }
+
     int numColours = minColour;
 
     //start the iterations
@@ -27,19 +31,16 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
     for(i = 0; i < maxIterations; i++) {
         int numChanges = 0;
 
-        node** agentsCopy = (node**)malloc(sizeof(node*) * numAgents);
-        memcpy(agentsCopy, agents, sizeof(node*) * numAgents);
-
         //each agent makes changes to the graph
         for(int a = 0; a < numAgents; a++) {
             numChanges += agentController(&agents[a], numMoves, numColours);
-            if(dynamicKernel != NULL) {
-                dynamicKernel(&colouringGraph, &numNodes, agents[a], &agentsCopy, &numAgents);
-            }
         }
 
-        free(agents);
-        agents = agentsCopy;
+        if(dynamicKernel != NULL) {
+            for(int a = 0; a < numAgents; a++) {
+                dynamicKernel(&colouringGraph, &numNodes, agents[a], &agents, &numAgents);
+            }
+        }
 
         //CONSIDER: this is pretty slow; should i include this every iteration or maybe every nth iteration?
         if(save) {

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -20,10 +20,6 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
     //pick some starting nodes for the agents
     node** agents = fetchNUniqueNodes(colouringGraph, numNodes, numAgents);
 
-    for(int a = 0; a < numAgents; a++) {
-        printf("%d\n", agents[a]->id);
-    }
-
     int numColours = minColour;
 
     //start the iterations

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -304,7 +304,7 @@ int removeEdge(node* nodeReference, node* neighbourReference) {
             foundNeighbour = 1;
             
             //move each neighbour up one
-            for(int j = i; j < nodeReference->degree; j++) {
+            for(int j = i; j < nodeReference->degree - 1; j++) {
                 nodeReference->neighbours[j] = nodeReference->neighbours[j + 1];
             }
 
@@ -322,10 +322,8 @@ int removeEdge(node* nodeReference, node* neighbourReference) {
 
     for(int i = 0; i < neighbourReference->degree; i++) {
         if(neighbourReference->neighbours[i] == nodeReference) {
-            foundNeighbour = 1;
-            
             //move each neighbour up one
-            for(int j = i; j < neighbourReference->degree; j++) {
+            for(int j = i; j < neighbourReference->degree - 1; j++) {
                 neighbourReference->neighbours[j] = neighbourReference->neighbours[j + 1];
             }
 
@@ -338,6 +336,42 @@ int removeEdge(node* nodeReference, node* neighbourReference) {
     }
 
     return 1;
+}
+
+int makeNodeOrpan(node* targetNode) {
+    for(int n = 0; n < targetNode->degree; n++) {
+        removeEdge(targetNode, targetNode->neighbours[n]);
+    }
+
+    return 0;
+}
+
+int removeNode(node*** graphReference, int numNodes, node* targetNode) {
+    makeNodeOrpan(targetNode);
+
+    node** graph = *graphReference;
+
+    //find the nodes position in the array
+    //cant rely on id since other nodes might have been removed
+    int n;
+    for(n = 0; n < numNodes; n++) {
+        if(graph[n] == targetNode) break;
+    }
+
+    //free the memory
+    free(targetNode->neighbours);
+    free(targetNode);
+    targetNode = NULL;
+
+    //move all of the nodes up one
+    for(int i = n; n < numNodes - 1; i++) {
+        graph[i] = graph[i + 1];
+    }
+
+    //reallocate memory
+    (*graphReference) = (node**)realloc(*graphReference, sizeof(node*) * (numNodes - 1));
+
+    return 0;
 }
 
 node* findNodeWithHighestDegree(node** graph, int numNodes) {

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -138,10 +138,10 @@ int findNumUncolouredNodes(node** graph, int numNodes) {
 }
 
 node** fetchNUniqueNodes(node** fullGraph, int numNodes, int n) {
-    if(n >= numNodes) {
-        return fullGraph;
+    if(n > numNodes) {
+        n = numNodes;   //cannot create more agents than nodes
     }
-    
+
     node** nodes = (node**)malloc(sizeof(node*) * n);
 
     int* selectedIndex = (int*)calloc(numNodes, sizeof(int));

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -305,7 +305,6 @@ int removeEdge(node* nodeReference, node* neighbourReference) {
             
             //move each neighbour up one
             for(int j = i; j < nodeReference->degree - 1; j++) {
-            for(int j = i; j < nodeReference->degree - 1; j++) {
                 nodeReference->neighbours[j] = nodeReference->neighbours[j + 1];
             }
 

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -371,8 +371,6 @@ int makeNodeOrpan(node* targetNode) {
 int removeNode(node*** graphReference, int numNodes, node* targetNode) {
     makeNodeOrpan(targetNode);
 
-    printf("made node orphan\n");
-
     node** graph = *graphReference;
 
     //find the nodes position in the array
@@ -387,19 +385,13 @@ int removeNode(node*** graphReference, int numNodes, node* targetNode) {
     free(targetNode);
     targetNode = NULL;
 
-    printf("freed memory\n");
-
     //move all of the nodes up one
     for(int i = n; i < numNodes - 1; i++) {
         graph[i] = graph[i + 1];
     }
 
-    printf("reassigned nodes\n");
-
     //reallocate memory
     (*graphReference) = (node**)realloc(*graphReference, sizeof(node*) * (numNodes - 1));
-
-    printf("reallocated memory\n");
 
     return 0;
 }

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -325,7 +325,6 @@ int removeEdge(node* nodeReference, node* neighbourReference) {
         if(neighbourReference->neighbours[i] == nodeReference) {
             //move each neighbour up one
             for(int j = i; j < neighbourReference->degree - 1; j++) {
-            for(int j = i; j < neighbourReference->degree - 1; j++) {
                 neighbourReference->neighbours[j] = neighbourReference->neighbours[j + 1];
             }
 

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -352,7 +352,7 @@ int makeNodeOrpan(node* targetNode) {
 
                 neighbour->neighbours[neighbour->degree - 1] = NULL;
                 neighbour->neighbours = (node**)realloc(neighbour->neighbours, sizeof(node*) * (neighbour->degree - 1));
-                neighbour->degree--;
+                neighbour->degree -= 1;
 
                 break;
             }

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -339,15 +339,39 @@ int removeEdge(node* nodeReference, node* neighbourReference) {
 }
 
 int makeNodeOrpan(node* targetNode) {
+    //for each neighbour
     for(int n = 0; n < targetNode->degree; n++) {
-        removeEdge(targetNode, targetNode->neighbours[n]);
+        //remove targetNode reference from the neighbour
+        node* neighbour = targetNode->neighbours[n];
+
+        for(int i = 0; i < neighbour->degree; i++) {
+            if(neighbour->neighbours[i] == targetNode) {
+                for(int j = i; j < neighbour->degree - 1; j++) {
+                    neighbour->neighbours[j] = neighbour->neighbours[j + 1];
+                }
+
+                neighbour->neighbours[neighbour->degree - 1] = NULL;
+                neighbour->neighbours = (node**)realloc(neighbour->neighbours, sizeof(node*) * (neighbour->degree - 1));
+                neighbour->degree--;
+            }
+        }
     }
+
+    //remove all neighbours from targetNode
+    for(int n = 0; n < targetNode->degree; n++) {
+        targetNode->neighbours[n] = NULL;
+    }
+
+    targetNode->neighbours = NULL;
+    free(targetNode->neighbours);
 
     return 0;
 }
 
 int removeNode(node*** graphReference, int numNodes, node* targetNode) {
     makeNodeOrpan(targetNode);
+
+    printf("made node orphan\n");
 
     node** graph = *graphReference;
 
@@ -363,13 +387,19 @@ int removeNode(node*** graphReference, int numNodes, node* targetNode) {
     free(targetNode);
     targetNode = NULL;
 
+    printf("freed memory\n");
+
     //move all of the nodes up one
-    for(int i = n; n < numNodes - 1; i++) {
+    for(int i = n; i < numNodes - 1; i++) {
         graph[i] = graph[i + 1];
     }
 
+    printf("reassigned nodes\n");
+
     //reallocate memory
     (*graphReference) = (node**)realloc(*graphReference, sizeof(node*) * (numNodes - 1));
+
+    printf("reallocated memory\n");
 
     return 0;
 }

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -369,6 +369,10 @@ int makeNodeOrpan(node* targetNode) {
 }
 
 int removeNode(node*** graphReference, int numNodes, node* targetNode) {
+    if(targetNode == NULL) {
+        return 1;
+    }
+    
     makeNodeOrpan(targetNode);
 
     node** graph = *graphReference;

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -353,6 +353,8 @@ int makeNodeOrpan(node* targetNode) {
                 neighbour->neighbours[neighbour->degree - 1] = NULL;
                 neighbour->neighbours = (node**)realloc(neighbour->neighbours, sizeof(node*) * (neighbour->degree - 1));
                 neighbour->degree--;
+
+                break;
             }
         }
     }


### PR DESCRIPTION
one of the most commit-heavy pull requests I have made yet. this change adds the structural functionality to add dynamic kernels, which are called on the graph to make changes to it on every generation. these functions take entirely pointers as parameters, and update the graph as well as the agents array, and the values which keep track of their size (`numNodes` and `numAgents`).

there are two kernels already built in: the `possiblyRemoveEdgeKernel` possibly removes an edge between the agent and a random one of its neighbours, the `possiblyRemoveNodeKernel` possibly removes the agent node from the graph entirely.

this change made me spend hours debugging in order to figure out how i was managing to crash the program when i removed the nodes. i initially thought my only problem was the `makeNodeOrphan` function, which was simply not a good idea. i was basically modifying the memory of the thing i was iterating over again and again while also moving up; it was just bad. however, this did not solve all of my problems.

for a long time i was convinced that it was something to do with the memory managent, or the iteration over a list i was modifying (like before). in the end, the problem was a single `break;` statement, which meant i was only removing the first instance of the target pointer from the agent list, leading to illegal memory access when that missed pointer was accessed at some later place in the program. in short, i was [dereferencing a null pointer](https://youtu.be/bLHL75H_VEM?si=6ZJB_Pnxavnl2gZf).

i can definitely feel myself moving towards a precarious point with the development of this program; big new features like this are becoming more complicated to keep track of, but the consistent implementation prior to this with things like `graphUtil` functions has kept things relatively simple. this should be the last major addition like this; from here on in, it should hopefully be mainly new kernels which allow for interesting avenues of research.

![](https://i.makeagif.com/media/10-14-2022/dYRhL0.gif)
