### PR TITLE
bad actor kernel

### DIFF
--- a/include/colouringKernels.h
+++ b/include/colouringKernels.h
@@ -29,4 +29,6 @@ int randomKernel(node** agentPointer, int numMoves, int maxColour);
 //MOVES:        moves the agent to a random neighbour
 int edgeChopperKernel(node** agentPointer, int numMoves, int maxColour);
 
+int amongUsKernel(node** agentPointer, int numMoves, int maxColour);
+
 #endif

--- a/include/dynamicKernels.h
+++ b/include/dynamicKernels.h
@@ -7,4 +7,6 @@ int possiblyRemoveEdgeKernel(node*** graphReference, int* numNodes, node* agent,
 
 int possiblyRemoveNodeKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents);
 
+int removeOrphanNodesKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents);
+
 #endif

--- a/include/graphutil.h
+++ b/include/graphutil.h
@@ -93,4 +93,8 @@ int addEdgeBetweenNodes(node* nodeOne, node* nodeTwo);
 //will be returned 
 node* findNodeWithHighestDegree(node** graph, int numNodes);
 
+//this function modifies the provided list and list length in order to remove
+//the provided pointer from the list
+int removeAllInstancesOfNodePointerFromList(node*** nodeList, node* targetPointer, int* listLength);
+
 #endif

--- a/include/graphutil.h
+++ b/include/graphutil.h
@@ -97,4 +97,12 @@ node* findNodeWithHighestDegree(node** graph, int numNodes);
 //the provided pointer from the list
 int removeAllInstancesOfNodePointerFromList(node*** nodeList, node* targetPointer, int* listLength);
 
+//returns a vector of numbers representing how many times each colour
+//appeared at in the graph
+int* findColourFrequencies(node** graph, int numNodes, int maxColour);
+
+//extension of findColourFrequencies which extracts the highest value in the graph
+//will return the smallest colour if there is a tie
+int findMostCommonColourInGraph(node** graph, int numNodes, int maxColour);
+
 #endif

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -125,8 +125,8 @@ int main(int argc, char const *argv[]) {
         }
 
 
-        int (*agentController) (node**, int, int) = &minimumAgent;
-        int (*dynamicKernel) (node***, int*, node*, node***, int*) = &possiblyRemoveNodeKernel;
+        int (*agentController) (node**, int, int) = &amongUsKernel;
+        int (*dynamicKernel) (node***, int*, node*, node***, int*) = NULL;
 
         //colour the graph
         benchmarkMinimumGraph = minimumColour(graph, numNodes);

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -172,29 +172,26 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
         badActorSelected = 1;
     }
 
-    int* coloursInLocality = findWhichColoursInGraph(agent->neighbours, agent->degree, maxColour);
-
-    coloursInLocality[agent->colour] = 1;
-
-    int max = agent->colour ? agent->colour : maxColour;
-
     //colour the node
     if(agent == badActor) {
         //set the colour to the most common among its neighbours
-        for(int n = 0; n < agent->degree; n++) {
-
-        }
+        agent->colour = findMostCommonColourInGraph(agent->neighbours, agent->degree, maxColour);
     }
     else {
+        int* coloursInLocality = findWhichColoursInGraph(agent->neighbours, agent->degree, maxColour);
+        coloursInLocality[agent->colour] = 1;
+        int max = agent->colour ? agent->colour : maxColour;
+
         for(int c = 1; c < max; c++) {
             if(!coloursInLocality[c]) {
                 agent->colour = c;
                 numChanges = 1;
             }
         }
+
+        free(coloursInLocality);
     }
 
-    free(coloursInLocality);
 
     //move the agent(?)
     for(int m = 0; m < numMoves; m++) {

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -199,6 +199,11 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
                 if(!agent->neighbours[nb]->colour) {
                     *agentPointer = agent->neighbours[nb];
                     agent = *agentPointer;
+
+                    if(agent = badActor) {
+                        badActor = agent;
+                    }
+
                     break;
                 }
             }
@@ -213,6 +218,7 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
 
             *agentPointer = minColourNode;
             agent = *agentPointer;
+            badActor = agent;
         }
         else {
             node* maxColourNode = agent->neighbours[0];
@@ -229,6 +235,7 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
 
     //if the collective is confident in their choice of imposter
     //makeNodeOrphan(badActor)
+    //can pair this with a remove orphan dynamic kernel to remove the voted nodes from the graph entirely
 
     return numChanges;
 }

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -165,29 +165,29 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
         badActorSelected = 1;
     }
 
-    int* colours = findWhichColoursInGraph(agent->neighbours, agent->degree, maxColour);
+    int* coloursInLocality = findWhichColoursInGraph(agent->neighbours, agent->degree, maxColour);
 
-    colours[agent->colour] = 1;
+    coloursInLocality[agent->colour] = 1;
 
     int max = agent->colour ? agent->colour : maxColour;
 
     //colour the node
     if(agent == badActor) {
-        if(agent->colour < maxColour) {
-            agent->colour = maxColour;
-            numChanges = 1;
+        //set the colour to the most common among its neighbours
+        for(int n = 0; n < agent->degree; n++) {
+
         }
     }
     else {
         for(int c = 1; c < max; c++) {
-            if(!colours[c]) {
+            if(!coloursInLocality[c]) {
                 agent->colour = c;
                 numChanges = 1;
             }
         }
     }
 
-    free(colours);
+    free(coloursInLocality);
 
     //move the agent
     for(int m = 0; m < numMoves; m++) {
@@ -236,6 +236,9 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
     //if the collective is confident in their choice of imposter
     //makeNodeOrphan(badActor)
     //can pair this with a remove orphan dynamic kernel to remove the voted nodes from the graph entirely
+    //vote every maxColour iterations?
+    //vote on an array of pointers that represent nodes (remove the ability for agents to move for now)
+    //  or maybe only the bad actor can/cannot move
 
     return numChanges;
 }

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -145,3 +145,15 @@ int edgeChopperKernel(node** agentPointer, int numMoves, int maxColour) {
 
     return numChanges;
 }
+
+node* badActor;
+int badActorSelected = 0;   //boolean flag(?)
+
+int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
+    //if the agent is the bad actor, it should pick the least optimal colour
+    //if it is a normal node, it should do a normal colouring
+    //normal nodes can also vote for the neighbour they believe is the bad actor
+    //if the normal nodes manage to identify the bad actor, they can remove it
+
+    return 0;
+}

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -204,7 +204,13 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
             }
 
             if(!voted) {
+                //create a new pointer to vote for
+                struct voteStruct newVote;
+                newVote.count = 1;
+                newVote.nodePointer = nodeVote;
+
                 badActorVotes = (vote*)realloc(badActorVotes, sizeof(vote) * ++numVotes);
+                badActorVotes[numVotes - 1] = newVote;
             }
         }
 
@@ -238,7 +244,7 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
         }
 
         //make the voted node an orphan
-        if(mostVotes->count > 0) {
+        if(mostVotes->count > 1) {
             makeNodeOrpan(mostVotes->nodePointer);
         }
 

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -153,8 +153,14 @@ node* badActor;
 int badActorSelected = 0;   //boolean flag(?)
 
 //implementation variables
-int kernalCallNumber = 0;   //keeps track of the number of times the kernal has been incremented
-node** badActorVotes;
+typedef struct voteStruct {
+    node* nodePointer;
+    int count;
+} vote;
+
+int kernelCallNumber = 0;   //keeps track of the number of times the kernal has been incremented
+vote* badActorVotes;
+int numVotes = 0;
 
 int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
     //if the agent is the bad actor, it should pick the least optimal colour
@@ -162,7 +168,7 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
     //normal nodes can also vote for the neighbour they believe is the bad actor
     //if the normal nodes manage to identify the bad actor, they can remove it
 
-    kernalCallNumber++;
+    kernelCallNumber++;
 
     int numChanges = 0;
 
@@ -185,13 +191,21 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
     else {
         //vote for the bad actor
         if(nodeIsInConflict(agent)) {
-            badActorVotes = (node**)realloc(badActorVotes, sizeof(node*) * kernalCallNumber);
-
             node** conflictingNodes = findAllConflictingNodesInGraph(agent->neighbours, agent->degree);
-
-            badActorVotes[kernalCallNumber] = conflictingNodes[0];  //there should only be one conflicting node anyway
-
+            node* nodeVote = conflictingNodes[0];
             free(conflictingNodes);
+
+            int voted = 0;
+            for(int i = 0; i < numVotes; numVotes++) {
+                if(badActorVotes[i].nodePointer = nodeVote) {
+                    badActorVotes[i].count++;
+                    voted = 1;
+                }
+            }
+
+            if(!voted) {
+                badActorVotes = (vote*)realloc(badActorVotes, sizeof(vote) * ++numVotes);
+            }
         }
 
         //colour the node
@@ -210,14 +224,27 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
     }
 
     //tally vote results
-    if(kernalCallNumber >= maxColour) {
+    if(kernelCallNumber >= maxColour) {
         //loop over the array, keeping track of whether a pointer has been seen before with a truth vector
         //when we encounter a new pointer, iterate over the entire array to count how many times it appears
         //or create a vote struct, which has the pointer value and the count
         //then just loop over it twice-ish
 
+        vote* mostVotes;
+        for(int i = 0; i < numVotes; i++) {
+            if(mostVotes == NULL || badActorVotes[i].count > mostVotes->count) {
+                mostVotes = &badActorVotes[i];
+            }
+        }
+
+        //make the voted node an orphan
+        if(mostVotes->count > 0) {
+            makeNodeOrpan(mostVotes->nodePointer);
+        }
+
         //reset
-        kernalCallNumber = 0;
+        kernelCallNumber = 0;
+        numVotes = 0;
         free(badActorVotes);
         badActorVotes = NULL;
     }

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -174,11 +174,9 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
 
     //colour the node
     if(agent == badActor) {
-        for(int c = max - 1; c > 0; c--) {
-            if(!colours[c]) {
-                agent->colour = c;
-                numChanges = 1;
-            }
+        if(agent->colour < maxColour) {
+            agent->colour = maxColour;
+            numChanges = 1;
         }
     }
     else {
@@ -191,6 +189,45 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
     }
 
     free(colours);
+
+    //move the agent
+    for(int m = 0; m < numMoves; m++) {
+        if(agent->degree == 0) {
+            break;  //cant move the agent; on an orphan node
+        }
+        else if(findNumUncolouredNodes(agent->neighbours, agent->degree) > 0) {
+            for(int nb = 0; nb < agent->degree; nb++) {
+                if(!agent->neighbours[nb]->colour) {
+                    *agentPointer = agent->neighbours[nb];
+                    agent = *agentPointer;
+                    break;
+                }
+            }
+        }
+        else if(agent == badActor) {
+            node* minColourNode = agent->neighbours[0];
+            for(int nb = 0; nb < agent->degree; nb++) {
+                if(agent->neighbours[nb]->colour < minColourNode->colour) {
+                    minColourNode = agent->neighbours[nb];
+                }
+            }
+
+            *agentPointer = minColourNode;
+            agent = *agentPointer;
+        }
+        else {
+            node* maxColourNode = agent->neighbours[0];
+            for(int nb = 0; nb < agent->degree; nb++) {
+                if(agent->neighbours[nb]->colour > maxColourNode->colour) {
+                    maxColourNode = agent->neighbours[nb];
+                }
+            }
+
+            *agentPointer = maxColourNode;
+            agent = *agentPointer;
+        }
+    }
+
 
     return numChanges;
 }

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -146,14 +146,21 @@ int edgeChopperKernel(node** agentPointer, int numMoves, int maxColour) {
     return numChanges;
 }
 
+// ##### AMONG US KERNEL #####
+
+//functional variables
 node* badActor;
 int badActorSelected = 0;   //boolean flag(?)
+
+//implementation variables
+int kernalCallNumber = 0;   //keeps track of the number of times the kernal has been incremented
 
 int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
     //if the agent is the bad actor, it should pick the least optimal colour
     //if it is a normal node, it should do a normal colouring
     //normal nodes can also vote for the neighbour they believe is the bad actor
     //if the normal nodes manage to identify the bad actor, they can remove it
+    kernalCallNumber++;
 
     int numChanges = 0;
 
@@ -189,7 +196,7 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
 
     free(coloursInLocality);
 
-    //move the agent
+    //move the agent(?)
     for(int m = 0; m < numMoves; m++) {
         if(agent->degree == 0) {
             break;  //cant move the agent; on an orphan node

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -148,7 +148,6 @@ int edgeChopperKernel(node** agentPointer, int numMoves, int maxColour) {
 
 node* badActor;
 int badActorSelected = 0;   //boolean flag(?)
-node** badActorVotes;
 
 int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
     //if the agent is the bad actor, it should pick the least optimal colour
@@ -228,6 +227,8 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
         }
     }
 
+    //if the collective is confident in their choice of imposter
+    //makeNodeOrphan(badActor)
 
     return numChanges;
 }

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -148,6 +148,7 @@ int edgeChopperKernel(node** agentPointer, int numMoves, int maxColour) {
 
 node* badActor;
 int badActorSelected = 0;   //boolean flag(?)
+node** badActorVotes;
 
 int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
     //if the agent is the bad actor, it should pick the least optimal colour
@@ -155,5 +156,41 @@ int amongUsKernel(node** agentPointer, int numMoves, int maxColour) {
     //normal nodes can also vote for the neighbour they believe is the bad actor
     //if the normal nodes manage to identify the bad actor, they can remove it
 
-    return 0;
+    int numChanges = 0;
+
+    node* agent = *agentPointer;
+
+    //select the bad actor
+    if(!badActorSelected && rand() % 100 == 0) {
+        badActor = agent;
+        badActorSelected = 1;
+    }
+
+    int* colours = findWhichColoursInGraph(agent->neighbours, agent->degree, maxColour);
+
+    colours[agent->colour] = 1;
+
+    int max = agent->colour ? agent->colour : maxColour;
+
+    //colour the node
+    if(agent == badActor) {
+        for(int c = max - 1; c > 0; c--) {
+            if(!colours[c]) {
+                agent->colour = c;
+                numChanges = 1;
+            }
+        }
+    }
+    else {
+        for(int c = 1; c < max; c++) {
+            if(!colours[c]) {
+                agent->colour = c;
+                numChanges = 1;
+            }
+        }
+    }
+
+    free(colours);
+
+    return numChanges;
 }

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -13,28 +13,21 @@ int possiblyRemoveEdgeKernel(node*** graphReference, int* numNodes, node* agent,
 
 int possiblyRemoveNodeKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents) {
     if(rand() % 1000 == 0) {
-
-        node** agents = *agentsReference;
-
-        //remove the pointer from the agents array if necessary
         removeNode(graphReference, *numNodes, agent);
-
-        //multiple agents may have moved onto the node
-        int countValidAgents = 0;
-        node** remainingAgents = (node**)malloc(sizeof(node*) * (*numAgents));
-        for(int a = 0; a < *numAgents; a++) {
-            if(agents[a] != agent) {
-                remainingAgents[countValidAgents++] = agents[a];
-            }
-        }
-
-        remainingAgents = (node**)realloc(remainingAgents, sizeof(node*) * countValidAgents);
-        free(agents);
-        *agentsReference = remainingAgents;
-        *numAgents = countValidAgents;
-
-        //will only ever remove one node at a time
         *numNodes -= 1;
+
+        removeAllInstancesOfNodePointerFromList(agentsReference, agent, numAgents);
+    }
+
+    return 0;
+}
+
+int removeOrphanNodesKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents) {
+    if(agent->degree == 0) {
+        removeNode(graphReference, *numNodes, agent);
+        *numNodes -= 1;
+
+        removeAllInstancesOfNodePointerFromList(agentsReference, agent, numAgents);
     }
 
     return 0;

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -473,3 +473,26 @@ int removeAllInstancesOfNodePointerFromList(node*** nodeList, node* targetPointe
 
     return 0;
 }
+
+int* findColourFrequencies(node** graph, int numNodes, int maxColour) {
+    int* colourFreqVector = (int*)calloc(maxColour, sizeof(int));
+
+    for(int n = 0; n < numNodes; n++) {
+        colourFreqVector[graph[n]->colour]++;
+    }
+
+    return colourFreqVector;
+}
+
+int findMostCommonColourInGraph(node** graph, int numNodes, int maxColour) {
+    int* colourFreqVector = findColourFrequencies(graph, numNodes, maxColour);
+
+    int mostCommonColour = 0;
+    for(int i = 0; i < maxColour; i++) {
+        if(colourFreqVector[i] > mostCommonColour) {
+            mostCommonColour = i;
+        }
+    }
+
+    return mostCommonColour;
+}

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -494,5 +494,7 @@ int findMostCommonColourInGraph(node** graph, int numNodes, int maxColour) {
         }
     }
 
+    free(colourFreqVector);
+
     return mostCommonColour;
 }

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -454,3 +454,22 @@ node* findNodeWithHighestDegree(node** graph, int numNodes) {
     free(highestDegreeContenders);
     return highestDegreeNode;
 }
+
+int removeAllInstancesOfNodePointerFromList(node*** nodeList, node* targetPointer, int* listLength) {
+    node** list = *nodeList;
+    
+    int countValidAgents = 0;
+    node** remainingAgents = (node**)malloc(sizeof(node*) * (*listLength));
+    for(int n = 0; n < *listLength; n++) {
+        if(list[n] != targetPointer) {
+            remainingAgents[countValidAgents++] = list[n];
+        }
+    }
+
+    remainingAgents = (node**)realloc(remainingAgents, sizeof(node*) * countValidAgents);
+    free(list);
+    *nodeList = remainingAgents;
+    *listLength = countValidAgents;
+
+    return 0;
+}

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -365,6 +365,7 @@ int makeNodeOrpan(node* targetNode) {
     }
 
     targetNode->neighbours = NULL;
+    targetNode->degree = 0;
     free(targetNode->neighbours);
 
     return 0;


### PR DESCRIPTION
this change adds a kernel which allows the graph to play a game of among us. this does the following:
- the kernel will select a bad actor node
- if the current agent is a bad actor, it will colour the node with the colour that will cause the most conflicts
- if it is not the bad actor, it will colour it with the minimum possible colour (same as minimum agent)
- non-imposters can also select a neighbour that it believes is the bad actor
- when the kernel has been run `maxColour` times, then it will tally the current votes and makes the node with the most votes an orphan
   - it requires some consensus, so more than 1 vote
   - note that given the current way the non-imposters colour, they will always pick the imposter node

this implementation is open to be modified in the future, but this is a working version which produces results. also, while the kernel does have code which would allow the agents to move around, that will likely just break the implementation right now, so i would recommend not doing that.

this is also a kernel with centralised information; the votes, the number of calls to the kernel and the bad actor.

finally, this PR also includes some new utility functions which allow for the calculation of colour frequencies in a graph.

![](https://media1.tenor.com/m/LBuTdJpBQC0AAAAd/minecraft-mojang.gif)