### PR TITLE
bug fix: properly update the value of numNodes in main function

### DIFF
--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -3,7 +3,7 @@
 
 #include "node.h"
 
-node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, 
+node** agentColour(node** graph, int* numNodes, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, 
     int (*agentController)(node** agent, int numMoves, int numNodes),
     int (*dynamicKernel)(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents), int save);
 

--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -3,7 +3,7 @@
 
 #include "node.h"
 
-node** agentColour(node** graph, int* numNodes, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, 
+node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, 
     int (*agentController)(node** agent, int numMoves, int numNodes),
     int (*dynamicKernel)(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents), int save);
 

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -125,8 +125,8 @@ int main(int argc, char const *argv[]) {
         }
 
 
-        int (*agentController) (node**, int, int) = &amongUsKernel;
-        int (*dynamicKernel) (node***, int*, node*, node***, int*) = NULL;
+        int (*agentController) (node**, int, int) = &minimumAgent;
+        int (*dynamicKernel) (node***, int*, node*, node***, int*) = &possiblyRemoveNodeKernel;
 
         //colour the graph
         benchmarkMinimumGraph = minimumColour(graph, numNodes);
@@ -135,10 +135,7 @@ int main(int argc, char const *argv[]) {
             maxColour = findNumColoursUsed(benchmarkMinimumGraph, numNodes, numNodes + 1);
         }
 
-        colouredGraph = agentColour(graph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, agentController, dynamicKernel, save);
-
-        //measure the graph after colouring
-        numNodes = sizeof(colouredGraph) / sizeof(node*);
+        colouredGraph = agentColour(graph, &numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, agentController, dynamicKernel, save);
 
         if(verbose) {
             autoRuns = 1;   //should only run once if viewing the graph
@@ -150,7 +147,7 @@ int main(int argc, char const *argv[]) {
             printTraversalModeCommands();
             while(traverseGraph(colouredGraph, numNodes, highestDegreeNode, 1) < 0) {
                 //run it again
-                colouredGraph = agentColour(colouredGraph, numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, agentController, dynamicKernel, save);
+                colouredGraph = agentColour(colouredGraph, &numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, agentController, dynamicKernel, save);
             }
         }
 

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -8,9 +8,11 @@
 #define AGENT_BREAK_LIMIT 10
 #define COLOUR_INCREASE_LIMIT 2
 
-node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, 
+node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, 
     int (*agentController)(node**, int, int), int (*dynamicKernel)(node***, int*, node*, node***, int*), int save)
 {
+    int numNodes = *numNodesPtr;
+
     node** colouringGraph = copyGraph(graph, numNodes);
 
     int* problemsAtIteration = (int*)malloc(sizeof(int) * maxIterations);
@@ -59,8 +61,18 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
         }
     }
 
-    printf("number of agents: %d; number of colours: %d; number of conflicts: %d; number of missed nodes: %d\n", 
-        numAgents, findNumColoursUsed(colouringGraph, numNodes, numNodes), findNumConflicts(colouringGraph, numNodes), findNumUncolouredNodes(colouringGraph, numNodes));
+
+    printf("number of nodes at start: %d\nnumber of nodes now: %d\nnumber of agents: %d\nnumber of colours: %d\nnumber of conflicts: %d\nnumber of missed nodes: %d\n", 
+        *numNodesPtr,
+        numNodes,
+        numAgents,
+        findNumColoursUsed(colouringGraph, numNodes, numNodes),
+        findNumConflicts(colouringGraph, numNodes),
+        findNumUncolouredNodes(colouringGraph, numNodes)
+    );
+
+    //update original value of numNodes
+    *numNodesPtr = numNodes;
 
     if(save) {
         // write to csv file


### PR DESCRIPTION
this is a change to fix a bug i noticed where i had updated the value of `numNodes` in the main function by doing pointer division, which does not make any sense. i basically did not think this through, and was actually freeing just 1 of the nodes before the program terminated, which did stop it from crashing when the number of nodes changed but was ultimately incorrect. the only viable fix is to propogate the changes by passing the value for `numNodes` by reference, allowing me to copy the value and then update it after the main loop.

this was kind of a blessing in disguise, as it actually allows for more stats in the report at the end of the program :)

 
![](https://media1.tenor.com/m/fTFTHTnj_rIAAAAC/mosca.gif)
