### PR TITLE
Add max to colourblind

### DIFF
--- a/src/colouring.c
+++ b/src/colouring.c
@@ -125,8 +125,8 @@ int main(int argc, char const *argv[]) {
         }
 
 
-        int (*agentController) (node**, int, int) = &minimumAgent;
-        int (*dynamicKernel) (node***, int*, node*, node***, int*) = &possiblyRemoveNodeKernel;
+        int (*agentController) (node**, int, int) = &colourblindFishAgentDecrement;
+        int (*dynamicKernel) (node***, int*, node*, node***, int*) = NULL;
 
         //colour the graph
         benchmarkMinimumGraph = minimumColour(graph, numNodes);

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -8,9 +8,11 @@ int colourblindFishAgentIncrement(node** fishPointer, int numMoves, int maxColou
     
     node* fish = *fishPointer;
 
+    int max = maxColour < fish->degree ? maxColour : fish->degree;
+
     //check for conflicts in neighbours
     if(!fish->colour || nodeIsInConflict(fish)) {
-        fish->colour = (fish->colour + 1) % (fish->degree + 1);
+        fish->colour = (fish->colour + 1) % (max + 1);
 
         if(!fish->colour) {
             fish->colour++;
@@ -33,12 +35,14 @@ int colourblindFishAgentDecrement(node** fishPointer, int numMoves, int maxColou
     
     node* fish = *fishPointer;
 
+    int max = maxColour < fish->degree ? maxColour : fish->degree;
+
     //check for conflicts in neighbours
     if(!fish->colour || nodeIsInConflict(fish)) {
         fish->colour--;
 
         if(fish->colour <= 0) {
-            fish->colour = fish->degree + 1;
+            fish->colour = max + 1;
         }
 
         numChanges = 1;

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -42,7 +42,7 @@ int colourblindFishAgentDecrement(node** fishPointer, int numMoves, int maxColou
         fish->colour--;
 
         if(fish->colour <= 0) {
-            fish->colour = max + 1;
+            fish->colour = max;
         }
 
         numChanges = 1;


### PR DESCRIPTION
this change makes the colour blind kernels make use of the `maxColour` parameter, which they hadn't before. 

note that because of their conflict-centric nature, setting a lower bound with `-c` is equivalent to setting the lower and upper bound to being the same value if that lower bound is deficient to colour the graph properly.

the graphs that running these kernels with a deficient $k$ brings are very satisfying to look at by the way.


![](https://media1.tenor.com/m/I6Pc7ujs43EAAAAC/weirdcore-obscure.gif)
