### PR TITLE
add timer

### DIFF
--- a/include/saving.h
+++ b/include/saving.h
@@ -10,7 +10,7 @@ int addBufferColumnToConflictsFile(int numColumns);
 
 //saves micellaneous data about the colouring run to a csv file
 int saveColouringData(int benchmark, int numNodesStart, int numNodesEnd, int numiterations, 
-    int numAgents, int numColours, int finalNumConflicts, int numMissedNodes);
+    int numAgents, int numColours, int finalNumConflicts, int numMissedNodes, double time);
 
 //adds a newline character to the file
 int addBufferRowToResultsFile(int numRows);

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -25,6 +25,11 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
 
     int numColours = minColour;
 
+    //start the timer
+    clock_t start = clock();
+
+    double ioTime = 0.0;    //time used to account for io operations
+
     //start the iterations
     int i;
     for(i = 0; i < maxIterations; i++) {
@@ -41,9 +46,15 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
             }
         }
 
-        //CONSIDER: this is pretty slow; should i include this every iteration or maybe every nth iteration?
         if(save) {
+            clock_t problemsStart = clock();
+
+            //this is not really "io", but it falls into the "io" category imo
+            //either way it takes a really long time
             problemsAtIteration[i] = findNumConflicts(colouringGraph, numNodes) + findNumUncolouredNodes(colouringGraph, numNodes);
+
+            clock_t problemsEnd = clock();
+            ioTime += (double)(problemsEnd - problemsStart) / CLOCKS_PER_SEC;
         }
 
         if(!numChanges) {
@@ -62,17 +73,17 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
         }
     }
 
+    clock_t end = clock();
+    double overallTime = (double)(end - start) / CLOCKS_PER_SEC;
+    double time = overallTime - ioTime; //subtract the time spent counting conflicts
+
     int finalNumColours = findNumColoursUsed(colouringGraph, numNodes, numNodes); 
     int numConflicts = findNumConflicts(colouringGraph, numNodes);
     int numMissedNodes = findNumUncolouredNodes(colouringGraph, numNodes);
 
-    printf("number of nodes at start: %d\nnumber of nodes now: %d\nnumber of agents: %d\nnumber of colours: %d\nnumber of conflicts: %d\nnumber of missed nodes: %d\n", 
-        *numNodesPtr,
-        numNodes,
-        numAgents,
-        finalNumColours,
-        numConflicts,
-        numMissedNodes
+    printf(
+        "number of nodes at start: %d\nnumber of nodes now: %d\nnumber of agents: %d\nnumber of colours: %d\nnumber of conflicts: %d\nnumber of missed nodes: %d\ntime: %.3f seconds\n\n", 
+        *numNodesPtr, numNodes, numAgents, finalNumColours, numConflicts, numMissedNodes, time
     );
 
     if(save) {

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -82,14 +82,14 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     int numMissedNodes = findNumUncolouredNodes(colouringGraph, numNodes);
 
     printf(
-        "number of nodes at start: %d\nnumber of nodes now: %d\nnumber of agents: %d\nnumber of colours: %d\nnumber of conflicts: %d\nnumber of missed nodes: %d\ntime: %.3f seconds\n\n", 
+        "number of nodes at start: %d\nnumber of nodes now: %d\nnumber of agents: %d\nnumber of colours: %d\nnumber of conflicts: %d\nnumber of missed nodes: %d\ntime: %.4f seconds\n\n", 
         *numNodesPtr, numNodes, numAgents, finalNumColours, numConflicts, numMissedNodes, time
     );
 
     if(save) {
         // write to csv file
         appendToResults(problemsAtIteration, i);
-        saveColouringData(maxColour, *numNodesPtr, numNodes, i, numAgents, finalNumColours, numConflicts, numMissedNodes);
+        saveColouringData(maxColour, *numNodesPtr, numNodes, i, numAgents, finalNumColours, numConflicts, numMissedNodes, time);
     }
 
     //update original value of numNodes

--- a/src/saving.c
+++ b/src/saving.c
@@ -134,11 +134,11 @@ int addBufferColumnToConflictsFile(int numColumns) {
 }
 
 int saveColouringData(int benchmark, int numNodesStart, int numNodesEnd, int numiterations, 
-    int numAgents, int numColours, int finalNumConflicts, int numMissedNodes)
+    int numAgents, int numColours, int finalNumConflicts, int numMissedNodes, double time)
 {
     FILE* results = fopen(RESULTS_SAVE_FILE_NAME, "a");
 
-    fprintf(results, "%d,%d,%d,%d,%d,%d,%d,%d\n",
+    fprintf(results, "%d,%d,%d,%d,%d,%d,%d,%d,%.4f\n",
         benchmark,
         numNodesStart,
         numNodesEnd,
@@ -146,7 +146,8 @@ int saveColouringData(int benchmark, int numNodesStart, int numNodesEnd, int num
         numAgents,
         numColours,
         finalNumConflicts,
-        numMissedNodes
+        numMissedNodes,
+        time
     );
 
     fclose(results);
@@ -173,7 +174,7 @@ int addHeadersToResultsFile(char* optionalDescription) {
         fprintf(results, "%s\n", optionalDescription);
     }
 
-    fprintf(results, "benchmark, starting nodes, final nodes, iterations, agents, colours, conflicts, missed nodes\n");
+    fprintf(results, "benchmark, starting nodes, final nodes, iterations, agents, colours, conflicts, missed nodes, time (s)\n");
 
     fclose(results);
 


### PR DESCRIPTION
this is a simple enough change. adds a timer to the main loop to see how long it took the program to complete. in order to get around the fact that counting the number of conflicts takes an absurdly long time, i have a sub-timer called `ioTime` that i increment as I go along. this value is subtracted from the `overallTime` in order to get the time the computer actually spent working on the graph.


![](https://media1.tenor.com/m/nqlbN07dGeQAAAAd/speedrun-half-life.gif)
