### PR TITLE
add kernel options

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,3 +4,6 @@ EXE_NAME = colouring
 
 compile: $(SRC_DIR)/*.c
 	g++ $(SRC_DIR)/*.c -I$(INCLUDE_DIR) -o $(EXE_NAME)
+
+debug: $(SRC_DIR)/*.c
+	g++ -g $(SRC_DIR)/*.c -I$(INCLUDE_DIR) -o $(EXE_NAME)

--- a/README.md
+++ b/README.md
@@ -84,16 +84,31 @@ options:
 -g [generator]    set the generator
                     sets the graph generator function to use
                     there are currently two different types of graphs you can use
-                    r: random graph; each edge has a p% chance of existing (default)
-                      options:
-                        -p [float]      probability (as a floating point number between 0 and 1)
-                                          probability that each edge of the graph exists
-                                          default is 0.5
-                    o: ring graph; undirected graph where each node has two neighbours
-                    b: bipartite graph; a graph of two disjoint subsets
-                      options:
-                        -s [integer]    set one; the number of nodes in the first subset
-                                          the default is to split the number of nodes in two
+                      r: random graph; each edge has a p% chance of existing (default)
+                        options:
+                          -p [float]      probability (as a floating point number between 0 and 1)
+                                            probability that each edge of the graph exists
+                                            default is 0.5
+                      o: ring graph; undirected graph where each node has two neighbours
+                      b: bipartite graph; a graph of two disjoint subsets
+                        options:
+                          -s [integer]    set one; the number of nodes in the first subset
+                                            the default is to split the number of nodes in two
+-k [kernel]       set the colouring kernel
+                    sets the kernel used to colour the nodes
+                    options include:
+                      m: local minimum (default); applies the local minimum colour
+                      r: random kernel; picks a colour between 1 and max if in conflict
+                      d: colour-blind decrement; decrements colour if in conflict
+                      i: colour-blind increment; increments colour if in conflict
+                    a: amongus kernel; introduces a bad actor (colours with m)
+-d [kernel]       set the dynamic kernel
+                    sets the kernel used to modify the topology of the graph
+                    options include:
+                      x: no dynamic kernel (default)
+                      e: possibly remove edge
+                      n: possibly remove node
+                      o: remove orphan nodes
 ```
 
 #### Example Usage

--- a/collect_results.sh
+++ b/collect_results.sh
@@ -1,4 +1,0 @@
-for p in $(seq 0.1 0.1 1)
-do
-    ./colouring -n 1000 -p $p -A 5 -S -M 10000
-done

--- a/collect_results.sh
+++ b/collect_results.sh
@@ -1,0 +1,4 @@
+for p in $(seq 0.1 0.1 1)
+do
+    ./colouring -n 1000 -p $p -A 5 -S -M 10000
+done

--- a/experiments.sh
+++ b/experiments.sh
@@ -31,7 +31,7 @@ for k in 5 10 25 50 100 200 250
 do
     for p in $(seq 0.1 0.1 1)
     do
-        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -S -M $MAXIMUM_ITERATIONS -k r
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k r
     done
 done
 
@@ -40,7 +40,7 @@ for k in 5 10 25 50 100 200 250
 do
     for p in $(seq 0.1 0.1 1)
     do
-        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -S -M $MAXIMUM_ITERATIONS -k d
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k d
     done
 done
 
@@ -49,7 +49,7 @@ for k in 5 10 25 50 100 200 250
 do
     for p in $(seq 0.1 0.1 1)
     do
-        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -S -M $MAXIMUM_ITERATIONS -k i
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k i
     done
 done
 

--- a/experiments.sh
+++ b/experiments.sh
@@ -1,0 +1,63 @@
+NUMBER_OF_NODES=100
+NUMBER_OF_AUTO_RUNS=2
+MAXIMUM_ITERATIONS=5000
+
+
+# UNLIMITED NUMBER OF COLOURS
+
+# random kernel
+for p in $(seq 0.1 0.1 1)
+do
+    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k r
+done
+
+# decrementing kernel
+for p in $(seq 0.1 0.1 1)
+do
+    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k d
+done
+
+# incrementing kernel
+for p in $(seq 0.1 0.1 1)
+do
+    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k i
+done
+
+
+# INCREASING LIMITS
+
+# random kernel
+for k in 5 10 25 50 100 200 250
+do
+    for p in $(seq 0.1 0.1 1)
+    do
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -S -M $MAXIMUM_ITERATIONS -k r
+    done
+done
+
+# decrementing kernel
+for k in 5 10 25 50 100 200 250
+do
+    for p in $(seq 0.1 0.1 1)
+    do
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -S -M $MAXIMUM_ITERATIONS -k d
+    done
+done
+
+# incrementing kernel
+for k in 5 10 25 50 100 200 250
+do
+    for p in $(seq 0.1 0.1 1)
+    do
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -S -M $MAXIMUM_ITERATIONS -k i
+    done
+done
+
+#minimum kernel
+for k in 5 10 25 50 100 200 250
+do
+    for p in $(seq 0.1 0.1 1)
+    do
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -S -M $MAXIMUM_ITERATIONS -k m
+    done
+done

--- a/experiments.sh
+++ b/experiments.sh
@@ -6,59 +6,49 @@ MAXIMUM_ITERATIONS=10000
 # UNLIMITED NUMBER OF COLOURS
 
 # random kernel
-# for p in $(seq 0.1 0.1 1)
-# do
-#     ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k r
-# done
+for p in $(seq 0.1 0.1 1)
+do
+    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k r
+done
 
-# # decrementing kernel
-# for p in $(seq 0.1 0.1 1)
-# do
-#     ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k d
-# done
+# decrementing kernel
+for p in $(seq 0.1 0.1 1)
+do
+    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k d
+done
 
-# # incrementing kernel
-# for p in $(seq 0.1 0.1 1)
-# do
-#     ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k i
-# done
+# incrementing kernel
+for p in $(seq 0.1 0.1 1)
+do
+    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k i
+done
 
 
-# # INCREASING LIMITS
+# INCREASING LIMITS
 
-# # random kernel
-# for k in 5 10 25 50 100 200 250
-# do
-#     for p in $(seq 0.1 0.1 1)
-#     do
-#         ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k r
-#     done
-# done
-
-# # decrementing kernel
-# for k in 5 10 25 50 100 200 250
-# do
-#     for p in $(seq 0.1 0.1 1)
-#     do
-#         ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k d
-#     done
-# done
-
-# # incrementing kernel
-# for k in 5 10 25 50 100 200 250
-# do
-#     for p in $(seq 0.1 0.1 1)
-#     do
-#         ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k i
-#     done
-# done
-
-#minimum kernel
+# random kernel
 for k in 5 10 25 50 100 200 250
 do
     for p in $(seq 0.1 0.1 1)
     do
-        echo "$p $k"
-        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k m
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k r
+    done
+done
+
+# decrementing kernel
+for k in 5 10 25 50 100 200 250
+do
+    for p in $(seq 0.1 0.1 1)
+    do
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k d
+    done
+done
+
+# incrementing kernel
+for k in 5 10 25 50 100 200 250
+do
+    for p in $(seq 0.1 0.1 1)
+    do
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k i
     done
 done

--- a/experiments.sh
+++ b/experiments.sh
@@ -1,63 +1,64 @@
-NUMBER_OF_NODES=100
-NUMBER_OF_AUTO_RUNS=2
-MAXIMUM_ITERATIONS=5000
+NUMBER_OF_NODES=300
+NUMBER_OF_AUTO_RUNS=1
+MAXIMUM_ITERATIONS=10000
 
 
 # UNLIMITED NUMBER OF COLOURS
 
 # random kernel
-for p in $(seq 0.1 0.1 1)
-do
-    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k r
-done
+# for p in $(seq 0.1 0.1 1)
+# do
+#     ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k r
+# done
 
-# decrementing kernel
-for p in $(seq 0.1 0.1 1)
-do
-    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k d
-done
+# # decrementing kernel
+# for p in $(seq 0.1 0.1 1)
+# do
+#     ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k d
+# done
 
-# incrementing kernel
-for p in $(seq 0.1 0.1 1)
-do
-    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k i
-done
+# # incrementing kernel
+# for p in $(seq 0.1 0.1 1)
+# do
+#     ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k i
+# done
 
 
-# INCREASING LIMITS
+# # INCREASING LIMITS
 
-# random kernel
-for k in 5 10 25 50 100 200 250
-do
-    for p in $(seq 0.1 0.1 1)
-    do
-        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k r
-    done
-done
+# # random kernel
+# for k in 5 10 25 50 100 200 250
+# do
+#     for p in $(seq 0.1 0.1 1)
+#     do
+#         ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k r
+#     done
+# done
 
-# decrementing kernel
-for k in 5 10 25 50 100 200 250
-do
-    for p in $(seq 0.1 0.1 1)
-    do
-        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k d
-    done
-done
+# # decrementing kernel
+# for k in 5 10 25 50 100 200 250
+# do
+#     for p in $(seq 0.1 0.1 1)
+#     do
+#         ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k d
+#     done
+# done
 
-# incrementing kernel
-for k in 5 10 25 50 100 200 250
-do
-    for p in $(seq 0.1 0.1 1)
-    do
-        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k i
-    done
-done
+# # incrementing kernel
+# for k in 5 10 25 50 100 200 250
+# do
+#     for p in $(seq 0.1 0.1 1)
+#     do
+#         ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k i
+#     done
+# done
 
 #minimum kernel
 for k in 5 10 25 50 100 200 250
 do
     for p in $(seq 0.1 0.1 1)
     do
-        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -S -M $MAXIMUM_ITERATIONS -k m
+        echo "$p $k"
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k m
     done
 done

--- a/help.txt
+++ b/help.txt
@@ -37,13 +37,28 @@ options:
 -g [generator]    set the generator
                     sets the graph generator function to use
                     there are currently two different types of graphs you can use
-                    r: random graph; each edge has a p% chance of existing (default)
-                      options:
-                        -p [float]      probability (as a floating point number between 0 and 1)
-                                          probability that each edge of the graph exists
-                                          default is 0.5
-                    o: ring graph; undirected graph where each node has two neighbours
-                    b: bipartite graph; a graph of two disjoint subsets
-                      options:
-                        -s [integer]    set one; the number of nodes in the first subset
-                                          the default is to split the number of nodes in two
+                      r: random graph; each edge has a p% chance of existing (default)
+                        options:
+                          -p [float]      probability (as a floating point number between 0 and 1)
+                                            probability that each edge of the graph exists
+                                            default is 0.5
+                      o: ring graph; undirected graph where each node has two neighbours
+                      b: bipartite graph; a graph of two disjoint subsets
+                        options:
+                          -s [integer]    set one; the number of nodes in the first subset
+                                            the default is to split the number of nodes in two
+-k [kernel]       set the colouring kernel
+                    sets the kernel used to colour the nodes
+                    options include:
+                      m: local minimum (default); applies the local minimum colour
+                      r: random kernel; picks a colour between 1 and max if in conflict
+                      d: colour-blind decrement; decrements colour if in conflict
+                      i: colour-blind increment; increments colour if in conflict
+                    a: amongus kernel; introduces a bad actor (colours with m)
+-d [kernel]       set the dynamic kernel
+                    sets the kernel used to modify the topology of the graph
+                    options include:
+                      x: no dynamic kernel (default)
+                      e: possibly remove edge
+                      n: possibly remove node
+                      o: remove orphan nodes

--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -7,14 +7,4 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     int (*agentController)(node** agent, int numMoves, int numNodes),
     int (*dynamicKernel)(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents), int save);
 
-int colourblindFishAgentIncrement(node** fishPointer, int numMoves, int maxColour);
-
-int colourblindFishAgentDecrement(node** fishPointer, int numMoves, int maxColour);
-
-int minimumAgent(node** agentPointer, int numMoves, int maxColour);
-
-int randomKernel(node** agentPointer, int numMoves, int maxColour);
-
-int edgeChopperKernel(node** agentPointer, int numMoves, int maxColour);
-
 #endif

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -21,7 +21,7 @@ int main(int argc, char const *argv[]) {
 
     int numNodes = 10;
     char generator = 'r';
-    int verbose = 0;
+    int visualise = 0;
     int autoRuns = 1;
     int maxIterations = 50000;
     int save = 0;   //boolean flag to save results to a csv file
@@ -38,6 +38,10 @@ int main(int argc, char const *argv[]) {
     //bipartite generator
     int nodesInSetOne = 0;
 
+    //kernels
+    int (*agentController) (node**, int, int) = &minimumAgent;
+    int (*dynamicKernel) (node***, int*, node*, node***, int*) = NULL;
+
     //CONSIDER: so many string comparisons; no better way?
     for(int i = 0; i < argc; i++) {
         if(!(*argv[i] == '-')) {
@@ -51,23 +55,23 @@ int main(int argc, char const *argv[]) {
         else if(!strcmp(argv[i], "-n")) {
             numNodes = atoi(argv[i + 1]);
         }
-        else if(!strcmp(argv[i], "-M")) {
-            maxIterations = atoi(argv[i + 1]);
-        }
         else if(!strcmp(argv[i], "-p")) {
             prob = atof(argv[i + 1]);
         }
         else if(!strcmp(argv[i], "-c")) {
             minColour = atoi(argv[i + 1]);
         }
-        else if(!strcmp(argv[i], "-C")) {
-            maxColour = atoi(argv[i + 1]);
+        else if(!strcmp(argv[i], "-M")) {
+            maxIterations = atoi(argv[i + 1]);
         }
         else if(!strcmp(argv[i], "-S")) {
             save = 1;
         }
         else if(!strcmp(argv[i], "-A")) {
             autoRuns = atoi(argv[i + 1]);
+        }
+        else if(!strcmp(argv[i], "-C")) {
+            maxColour = atoi(argv[i + 1]);
         }
         else if(!strcmp(argv[i], "-a")) {
             numAgents = atoi(argv[i + 1]);
@@ -76,7 +80,7 @@ int main(int argc, char const *argv[]) {
             numMoves = atoi(argv[i + 1]);
         }
         else if(!strcmp(argv[i], "-v")) {
-            verbose = 1;
+            visualise = 1;
         }
         else if(!strcmp(argv[i], "-g")) {
             generator = *argv[i + 1];
@@ -131,10 +135,6 @@ int main(int argc, char const *argv[]) {
                 return 1;
         }
 
-
-        int (*agentController) (node**, int, int) = &colourblindFishAgentDecrement;
-        int (*dynamicKernel) (node***, int*, node*, node***, int*) = NULL;
-
         //colour the graph
         benchmarkMinimumGraph = minimumColour(graph, numNodes);
         
@@ -144,7 +144,7 @@ int main(int argc, char const *argv[]) {
 
         colouredGraph = agentColour(graph, &numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, agentController, dynamicKernel, save);
 
-        if(verbose) {
+        if(visualise) {
             autoRuns = 1;   //should only run once if viewing the graph
 
             //find the highest degree node

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -39,8 +39,8 @@ int main(int argc, char const *argv[]) {
     int nodesInSetOne = 0;
 
     //kernels
-    int (*agentController) (node**, int, int) = &minimumAgent;
-    int (*dynamicKernel) (node***, int*, node*, node***, int*) = NULL;
+    char cKernelCode = 'm';
+    char dKernelCode = 'x';
 
     //CONSIDER: so many string comparisons; no better way?
     for(int i = 0; i < argc; i++) {
@@ -59,26 +59,7 @@ int main(int argc, char const *argv[]) {
             prob = atof(argv[i + 1]);
         }
         else if(!strcmp(argv[i], "-k")) {
-            switch ((int)argv[i+ 1]) {
-                case 'r':
-                    agentController = &randomKernel;
-                    break;
-                case 'd':
-                    agentController = &colourblindFishAgentDecrement;
-                    break;
-                case 'i':
-                    agentController = &colourblindFishAgentIncrement;
-                    break;
-                case 'a':
-                    agentController = &amongUsKernel;
-                    break;
-                case 'm':
-                    agentController = &minimumAgent;
-                    break;
-                default:
-                    printf("unknown kernel code; using default (m)\n");
-                    break;
-            }
+            cKernelCode = *argv[i + 1];
         }
         else if(!strcmp(argv[i], "-c")) {
             minColour = atoi(argv[i + 1]);
@@ -91,6 +72,9 @@ int main(int argc, char const *argv[]) {
         }
         else if(!strcmp(argv[i], "-A")) {
             autoRuns = atoi(argv[i + 1]);
+        }
+        else if(!strcmp(argv[i], "-d")) {
+            dKernelCode = *argv[i + 1];  
         }
         else if(!strcmp(argv[i], "-C")) {
             maxColour = atoi(argv[i + 1]);
@@ -123,6 +107,49 @@ int main(int argc, char const *argv[]) {
     }
 
     int useBenchmark = !maxColour ? 1 : 0;
+
+    //set colouring kernel
+    int (*agentController) (node**, int, int);
+    switch (cKernelCode) {
+        case 'r':
+            agentController = &randomKernel;
+            break;
+        case 'd':
+            agentController = &colourblindFishAgentDecrement;
+            break;
+        case 'i':
+            agentController = &colourblindFishAgentIncrement;
+            break;
+        case 'a':
+            agentController = &amongUsKernel;
+            break;
+        case 'm':
+            agentController = &minimumAgent;
+            break;
+        default:
+            printf("invalid colouring kernel\n");
+            return 1;
+    }
+
+    //set the dynamic kernel
+    int (*dynamicKernel) (node***, int*, node*, node***, int*);
+    switch (dKernelCode) {
+        case 'e':
+            dynamicKernel = &possiblyRemoveEdgeKernel;
+            break;
+        case 'n':
+            dynamicKernel = &possiblyRemoveNodeKernel;
+            break;
+        case 'o':
+            dynamicKernel = &removeOrphanNodesKernel;
+            break;
+        case 'x':
+            dynamicKernel = NULL;
+            break;
+        default:
+            printf("invalid dynamic kernel\n");
+            return 1;
+    }
 
     //graph variables
     node** graph;

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -58,6 +58,28 @@ int main(int argc, char const *argv[]) {
         else if(!strcmp(argv[i], "-p")) {
             prob = atof(argv[i + 1]);
         }
+        else if(!strcmp(argv[i], "-k")) {
+            switch ((int)argv[i+ 1]) {
+                case 'r':
+                    agentController = &randomKernel;
+                    break;
+                case 'd':
+                    agentController = &colourblindFishAgentDecrement;
+                    break;
+                case 'i':
+                    agentController = &colourblindFishAgentIncrement;
+                    break;
+                case 'a':
+                    agentController = &amongUsKernel;
+                    break;
+                case 'm':
+                    agentController = &minimumAgent;
+                    break;
+                default:
+                    printf("unknown kernel code; using default (m)\n");
+                    break;
+            }
+        }
         else if(!strcmp(argv[i], "-c")) {
             minColour = atoi(argv[i + 1]);
         }

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -158,7 +158,8 @@ int main(int argc, char const *argv[]) {
 
     if(save) {
         char description[100];
-        snprintf(description, 100, "generator: %c; no. nodes: %d; probability: %.3f;", generator, numNodes, prob);
+        snprintf(description, 100, "generator: %c; coloring kernel: %c; dynamic kernel: %c; no. nodes: %d; probability: %.3f;",
+            generator, cKernelCode, dKernelCode, numNodes, prob);
         addHeadersToResultsFile(description);
     }
 

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -77,7 +77,7 @@ int main(int argc, char const *argv[]) {
             dKernelCode = *argv[i + 1];  
         }
         else if(!strcmp(argv[i], "-C")) {
-            maxColour = atoi(argv[i + 1]);
+            maxColour = atoi(argv[i + 1]) - 1;
         }
         else if(!strcmp(argv[i], "-a")) {
             numAgents = atoi(argv[i + 1]);

--- a/src/saving.c
+++ b/src/saving.c
@@ -6,6 +6,8 @@
 #define CONFLICTS_SAVE_FILE_NAME "conflicts.csv"
 #define RESULTS_SAVE_FILE_NAME "results.csv"
 
+#define LINE_BUFFER_SIZE 5012
+
 int appendToResults(int* conflictArray, int numIterations) {
     FILE* results = fopen(CONFLICTS_SAVE_FILE_NAME, "r");
     FILE* temp = fopen("temp.csv", "w");
@@ -16,10 +18,10 @@ int appendToResults(int* conflictArray, int numIterations) {
 
     //write the new data
 
-    char line[1024];
+    char line[LINE_BUFFER_SIZE];
     int lineNum = 0;
 
-    while(fgets(line, 1024, results)) {
+    while(fgets(line, LINE_BUFFER_SIZE, results)) {
         
         //stop the write if a line exceeds the buffer size
         if(strchr(line, '\n') == NULL) {
@@ -48,7 +50,7 @@ int appendToResults(int* conflictArray, int numIterations) {
     if(lineNum < numIterations) {
         //count the number of columns in the old file
         rewind(results);
-        fgets(line, 1024, results); //get the first line of the file again
+        fgets(line, LINE_BUFFER_SIZE, results); //get the first line of the file again
         int numCols = 0;
         for(int i = 0; i < strlen(line); i++) {
             if(line[i] == ',') {


### PR DESCRIPTION
this change adds the ability to set the kernel to use as an option, for both colouring and dynamic kernels. this is a change that is mainly useful for running a lot of sequential experiments, as you can see in `experiments.sh`.

i also spent a long time debugging issue #26, which has driven me insane. either way, the changes introduced here work fine.

the `LINE_BUFFER_SIZE` is probably too large; i made it like that to read in massive lines, but the conflicts file ended up being pretty strangely formatted, so i think i should just run smaller scale experiments.

![](https://media1.tenor.com/m/4BRLN0wM9eIAAAAC/yoda-star-wars.gif) 