### PR TITLE
name the save file

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ options:
                     the default is determined by a brute force centralised approach
                     this paramter will have no effect if the lower bound is not also set
                     can be used to ensure that the solution is optimal or to force conflicts
--S                set the save mode on
+-S [name/path]    set the save mode on
                     flag which sets whether the results are saved to a file called results.csv
                     the default is false
+                    the name/path is optional, but allows for custom names or paths if included
 -A [integer]      number of automatic runs
                     default is 1 (run the program once)
                     increasing the number will run the program that number of times

--- a/experiments.sh
+++ b/experiments.sh
@@ -8,19 +8,19 @@ MAXIMUM_ITERATIONS=10000
 # random kernel
 for p in $(seq 0.1 0.1 1)
 do
-    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k r
+    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S res/r_unl -M $MAXIMUM_ITERATIONS -k r
 done
 
 # decrementing kernel
 for p in $(seq 0.1 0.1 1)
 do
-    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k d
+    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S res/d_unl -M $MAXIMUM_ITERATIONS -k d
 done
 
 # incrementing kernel
 for p in $(seq 0.1 0.1 1)
 do
-    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S -M $MAXIMUM_ITERATIONS -k i
+    ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -S res/i_unl -M $MAXIMUM_ITERATIONS -k i
 done
 
 
@@ -31,7 +31,7 @@ for k in 5 10 25 50 100 200 250
 do
     for p in $(seq 0.1 0.1 1)
     do
-        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k r
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S res/r_lmtd -M $MAXIMUM_ITERATIONS -k r
     done
 done
 
@@ -40,7 +40,7 @@ for k in 5 10 25 50 100 200 250
 do
     for p in $(seq 0.1 0.1 1)
     do
-        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k d
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S res/d_lmtd -M $MAXIMUM_ITERATIONS -k d
     done
 done
 
@@ -49,6 +49,6 @@ for k in 5 10 25 50 100 200 250
 do
     for p in $(seq 0.1 0.1 1)
     do
-        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S -M $MAXIMUM_ITERATIONS -k i
+        ./colouring -n $NUMBER_OF_NODES -p $p -A $NUMBER_OF_AUTO_RUNS -c $k -C $k -S res/i_lmtd -M $MAXIMUM_ITERATIONS -k i
     done
 done

--- a/help.txt
+++ b/help.txt
@@ -15,9 +15,10 @@ options:
                     the default is determined by a brute force centralised approach
                     this paramter will have no effect if the lower bound is not also set
                     can be used to ensure that the solution is optimal or to force conflicts
--S                set the save mode on
+-S [name/path]    set the save mode on
                     flag which sets whether the results are saved to a file called results.csv
                     the default is false
+                    the name/path is optional, but allows for custom names or paths if included
 -A [integer]      number of automatic runs
                     default is 1 (run the program once)
                     increasing the number will run the program that number of times

--- a/include/saving.h
+++ b/include/saving.h
@@ -19,4 +19,7 @@ int addBufferRowToResultsFile(int numRows);
 //if you do not want the description, pass `NULL`
 int addHeadersToResultsFile(char* optionalDescription);
 
+//prepends the default names with the provided string
+int setFileNamePrepend(char* name);
+
 #endif

--- a/include/saving.h
+++ b/include/saving.h
@@ -20,6 +20,7 @@ int addBufferRowToResultsFile(int numRows);
 int addHeadersToResultsFile(char* optionalDescription);
 
 //prepends the default names with the provided string
-int setFileNamePrepend(char* name);
+//sets the name for both results and conflicts saves
+int setFileNamePrepend(const char* name);
 
 #endif

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -69,6 +69,11 @@ int main(int argc, char const *argv[]) {
         }
         else if(!strcmp(argv[i], "-S")) {
             save = 1;
+
+            //if name file name is provided, set it
+            if(i + 1 < argc && !(*argv[i + 1] == '-') && setFileNamePrepend(argv[i + 1])) {
+                return 1;   //do not want to accidentally overwrite saved data
+            }
         }
         else if(!strcmp(argv[i], "-A")) {
             autoRuns = atoi(argv[i + 1]);

--- a/src/saving.c
+++ b/src/saving.c
@@ -15,11 +15,11 @@ char conflictsFullName[FULL_FILE_NAME_LENGTH] = CONFLICTS_SAVE_FILE_NAME;
 char resultsFullName[FULL_FILE_NAME_LENGTH] = RESULTS_SAVE_FILE_NAME;
 
 int appendToResults(int* conflictArray, int numIterations) {
-    FILE* results = fopen(CONFLICTS_SAVE_FILE_NAME, "r");
+    FILE* results = fopen(conflictsFullName, "r");
     FILE* temp = fopen("temp.csv", "w");
 
     if(results == NULL) {
-        results = fopen(CONFLICTS_SAVE_FILE_NAME, "w+");
+        results = fopen(conflictsFullName, "w+");
     }
 
     //write the new data
@@ -94,8 +94,8 @@ int appendToResults(int* conflictArray, int numIterations) {
     fclose(results);
     fclose(temp);
 
-    remove(CONFLICTS_SAVE_FILE_NAME);
-    rename("temp.csv", CONFLICTS_SAVE_FILE_NAME);
+    remove(conflictsFullName);
+    rename("temp.csv", conflictsFullName);
 
     return 0;
 }
@@ -106,7 +106,7 @@ int addBufferColumnToConflictsFile(int numColumns) {
         return 1;
     }
     
-    FILE* results = fopen(CONFLICTS_SAVE_FILE_NAME, "r");
+    FILE* results = fopen(conflictsFullName, "r");
     FILE* temp = fopen("temp.csv", "w");
 
     if(results == NULL) {
@@ -135,8 +135,8 @@ int addBufferColumnToConflictsFile(int numColumns) {
     fclose(results);
     fclose(temp);
 
-    remove(CONFLICTS_SAVE_FILE_NAME);
-    rename("temp.csv", CONFLICTS_SAVE_FILE_NAME);
+    remove(conflictsFullName);
+    rename("temp.csv", conflictsFullName);
 
     return 0;
 }
@@ -144,7 +144,7 @@ int addBufferColumnToConflictsFile(int numColumns) {
 int saveColouringData(int benchmark, int numNodesStart, int numNodesEnd, int numiterations, 
     int numAgents, int numColours, int finalNumConflicts, int numMissedNodes, double time)
 {
-    FILE* results = fopen(RESULTS_SAVE_FILE_NAME, "a");
+    FILE* results = fopen(resultsFullName, "a");
 
     fprintf(results, "%d,%d,%d,%d,%d,%d,%d,%d,%.4f\n",
         benchmark,
@@ -164,7 +164,7 @@ int saveColouringData(int benchmark, int numNodesStart, int numNodesEnd, int num
 }
 
 int addBufferRowToResultsFile(int numRows) {
-    FILE* results = fopen(RESULTS_SAVE_FILE_NAME, "a");
+    FILE* results = fopen(resultsFullName, "a");
 
     for(int i = 0; i < numRows; i++) {
         fprintf(results, "\n");
@@ -176,7 +176,7 @@ int addBufferRowToResultsFile(int numRows) {
 }
 
 int addHeadersToResultsFile(char* optionalDescription) {
-    FILE* results = fopen(RESULTS_SAVE_FILE_NAME, "a");
+    FILE* results = fopen(resultsFullName, "a");
 
     if(optionalDescription != NULL) {
         fprintf(results, "%s\n", optionalDescription);

--- a/src/saving.c
+++ b/src/saving.c
@@ -189,7 +189,7 @@ int addHeadersToResultsFile(char* optionalDescription) {
     return 0;
 }
 
-int setFileNamePrepend(char* name) {
+int setFileNamePrepend(const char* name) {
     if(name == NULL) {
         printf("no name provided\n");
         return 1;
@@ -206,13 +206,11 @@ int setFileNamePrepend(char* name) {
 
     //create conflicts name
     memcpy(conflictsFullName, name, nameLength);
-    memcpy(conflictsFullName + nameLength, name, conflictsLength);
-    printf("%s\n", conflictsFullName);
+    memcpy(conflictsFullName + nameLength, CONFLICTS_SAVE_FILE_NAME, conflictsLength);
 
     //create results name
     memcpy(resultsFullName, name, nameLength);
-    memcpy(resultsFullName + nameLength, name, resultsLength);
-    printf("%s\n", resultsFullName);
+    memcpy(resultsFullName + nameLength, RESULTS_SAVE_FILE_NAME, resultsLength);
 
     return 0;
 }

--- a/src/saving.c
+++ b/src/saving.c
@@ -8,6 +8,12 @@
 
 #define LINE_BUFFER_SIZE 5012
 
+#define FULL_FILE_NAME_LENGTH 30
+
+//variables to allow for custom file names
+char conflictsFullName[FULL_FILE_NAME_LENGTH] = CONFLICTS_SAVE_FILE_NAME;
+char resultsFullName[FULL_FILE_NAME_LENGTH] = RESULTS_SAVE_FILE_NAME;
+
 int appendToResults(int* conflictArray, int numIterations) {
     FILE* results = fopen(CONFLICTS_SAVE_FILE_NAME, "r");
     FILE* temp = fopen("temp.csv", "w");
@@ -179,6 +185,34 @@ int addHeadersToResultsFile(char* optionalDescription) {
     fprintf(results, "benchmark, starting nodes, final nodes, iterations, agents, colours, conflicts, missed nodes, time (s)\n");
 
     fclose(results);
+
+    return 0;
+}
+
+int setFileNamePrepend(char* name) {
+    if(name == NULL) {
+        printf("no name provided\n");
+        return 1;
+    }
+
+    int nameLength = strlen(name);
+    int conflictsLength = strlen(CONFLICTS_SAVE_FILE_NAME);
+    int resultsLength = strlen(RESULTS_SAVE_FILE_NAME);
+
+    if(nameLength > FULL_FILE_NAME_LENGTH - conflictsLength) {
+        printf("provided name too long\n");
+        return 1;
+    }
+
+    //create conflicts name
+    memcpy(conflictsFullName, name, nameLength);
+    memcpy(conflictsFullName + nameLength, name, conflictsLength);
+    printf("%s\n", conflictsFullName);
+
+    //create results name
+    memcpy(resultsFullName, name, nameLength);
+    memcpy(resultsFullName + nameLength, name, resultsLength);
+    printf("%s\n", resultsFullName);
 
     return 0;
 }


### PR DESCRIPTION
when i made the changes to improve saving in PR #23, i added the `LINE_BUFFER_SIZE` value with the assumption that it would allow for the entire line to be read in to memory, even when the lines became very, very large. this was incorrect, and it is simply not viable to keep increasing the buffer size. instead, this change allows for the inclusion of a custom file name/path that will be prepended to the default names. this will make it possible to run the experiments but simultaneously separate out the results. 

![](https://media1.tenor.com/m/wRCUEpT54E8AAAAC/anxiety-spongebob.gif)
