### PR TITLE
clean up benchmark code

### DIFF
--- a/src/centralisedgraphcolouring.c
+++ b/src/centralisedgraphcolouring.c
@@ -9,35 +9,26 @@
 node** minimumColour(node** graph, int numNodes) {
     node** colouringGraph = copyGraph(graph, numNodes);
 
-    int chromaticColour = numNodes;
+    int m = 1;
 
-    for(int m = 1; m < numNodes + 1; m++) {
+    // colour each node
+    for(int n = 0; n < numNodes; n++) {
 
-        for(int n = 0; n < numNodes; n++) {
+        // find the smallest colour possible to colour it with
+        for(int k = 1; k < m + 1; k++) {
 
-            for(int k = 1; k < m + 1; k++) {
+            colouringGraph[n]->colour = k;
 
-                colouringGraph[n]->colour = k;
-
-                if(!nodeIsInConflict(colouringGraph[n])) {
-                    break;
-                }
-                else if(k == m) {
-                    m++;
-                }
+            if(!nodeIsInConflict(colouringGraph[n])) {
+                break;  //break if the node is successfully coloured
             }
-        }
-
-        if(findNumConflicts(colouringGraph, numNodes) == 0) {
-            chromaticColour = m;
-            break;
-        }
-        else {
-            resetGraphColours(colouringGraph, numNodes);
+            else if(k == m) {
+                m++;    //increase m if there is no way to colour it properly
+            }
         }
     }
 
-    printf("centralised colour: %d\n", chromaticColour);
+    printf("centralised colour: %d\n", m);
 
     return colouringGraph;
 }


### PR DESCRIPTION
this change just reduces the amount of code in the benchmark function, since a lot of it is actually redundant now that i look at it again. i do not need to be increasing `m` in two different places. the colours of the graph were also never being reset, since the algorithm specifically does not colour the graph with conflicts.


![](https://media.tenor.com/sPGE00PcxlYAAAAi/nobody-cares-text.gif)
