### PR TITLE
set all kernels at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ options:
                       r: random kernel; picks a colour between 1 and max if in conflict
                       d: colour-blind decrement; decrements colour if in conflict
                       i: colour-blind increment; increments colour if in conflict
-                    a: amongus kernel; introduces a bad actor (colours with m)
+                      a: amongus kernel; introduces a bad actor (colours with m)
 -d [kernel]       set the dynamic kernel
                     sets the kernel used to modify the topology of the graph
                     options include:
@@ -116,6 +116,11 @@ options:
                       x: no movement kernel (default)
                       r: random movement kernel
                       o: optimal movement kernel
+-K [config]       set kernel config
+                    sets the kernel config based on the provided string
+                    the string is parsed in the format [colour, dynamic, movement]
+                    for example, the default configuration is 'mxx'
+                    colour-blind decrement with possible edge removal would be 'dex'
 ```
 
 #### Example Usage

--- a/help.txt
+++ b/help.txt
@@ -55,7 +55,7 @@ options:
                       r: random kernel; picks a colour between 1 and max if in conflict
                       d: colour-blind decrement; decrements colour if in conflict
                       i: colour-blind increment; increments colour if in conflict
-                    a: amongus kernel; introduces a bad actor (colours with m)
+                      a: amongus kernel; introduces a bad actor (colours with m)
 -d [kernel]       set the dynamic kernel
                     sets the kernel used to modify the topology of the graph
                     options include:
@@ -69,3 +69,8 @@ options:
                       x: no movement kernel (default)
                       r: random movement kernel
                       o: optimal movement kernel
+-K [config]       set kernel config
+                    sets the kernel config based on the provided string
+                    the string is parsed in the format [colour, dynamic, movement]
+                    for example, the default configuration is 'mxx'
+                    colour-blind decrement with possible edge removal would be 'dex'

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -43,6 +43,7 @@ int main(int argc, char const *argv[]) {
     char cKernelCode = 'm';
     char dKernelCode = 'x';
     char mKernelCode = 'x';
+    const char* kernelConfig;
 
     //CONSIDER: so many string comparisons; no better way?
     for(int i = 0; i < argc; i++) {
@@ -83,6 +84,14 @@ int main(int argc, char const *argv[]) {
         else if(!strcmp(argv[i], "-d")) {
             dKernelCode = *argv[i + 1];  
         }
+        else if(!strcmp(argv[i], "-K")) {
+            kernelConfig = argv[i + 1];
+            int configLength = strlen(kernelConfig);
+            if(configLength < 3 || configLength > 3) {
+                printf("invalid kernel config\n");
+                return 1;
+            }
+        }
         else if(!strcmp(argv[i], "-C")) {
             maxColour = atoi(argv[i + 1]) - 1;
         }
@@ -117,6 +126,13 @@ int main(int argc, char const *argv[]) {
     }
 
     int useBenchmark = !maxColour ? 1 : 0;
+
+    //set kernel config
+    if(kernelConfig != NULL) {
+        cKernelCode = kernelConfig[0];
+        dKernelCode = kernelConfig[1];
+        mKernelCode = kernelConfig[2];
+    }
 
     //set colouring kernel
     int (*colouringKernel) (node*, int);


### PR DESCRIPTION
this PR adds an exciting new CLI option which allows for all three kernels to be set with one flag. the `-K` option takes a string, which is parses into the format `[colour, dynamic, movement]` from which point the program continues as normal.

this is just a nice convenience addition.

![](https://media1.tenor.com/m/qXKst5vQxNEAAAAC/linux-among-us.gif)
