### PR TITLE
alternative colouring algorithm

### DIFF
--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -9,6 +9,6 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     node* (*movementKernel)(node* agent, int numMoves));
 
 node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* secondStartingNode, int minColour, int maxColour, int save,
-    int (*colouringKernel)(node**, int, int));
+    int (*colouringKernel)(node*, int));
 
 #endif

--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -8,6 +8,7 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     int (*dynamicKernel)(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents),
     node* (*movementKernel)(node* agent, int numMoves));
 
-node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* secondStartingNode, int (*colouringKernel)(node**, int, int), int minColour, int maxColour, int save);
+node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* secondStartingNode, int minColour, int maxColour, int save,
+    int (*colouringKernel)(node**, int, int));
 
 #endif

--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -7,6 +7,6 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     int (*agentController)(node** agent, int numMoves, int numNodes),
     int (*dynamicKernel)(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents), int save);
 
-node** pathColour(node** graph, int numNodes, int (*agentController)(node**, int, int), int minColour, int maxColour, int save);
+node** pathColour(node** graph, int numNodes, node* startingNode, int (*agentController)(node**, int, int), int minColour, int maxColour, int save);
 
 #endif

--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -8,6 +8,6 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     int (*dynamicKernel)(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents),
     node* (*movementKernel)(node* agent, int numMoves));
 
-node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* secondStartingNode, int (*agentController)(node**, int, int), int minColour, int maxColour, int save);
+node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* secondStartingNode, int (*colouringKernel)(node**, int, int), int minColour, int maxColour, int save);
 
 #endif

--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -7,6 +7,6 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     int (*agentController)(node** agent, int numMoves, int numNodes),
     int (*dynamicKernel)(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents), int save);
 
-node** pathColour(node** graph, int numNodes, node* startingNode, int (*agentController)(node**, int, int), int minColour, int maxColour, int save);
+node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* secondStartingNode, int (*agentController)(node**, int, int), int minColour, int maxColour, int save);
 
 #endif

--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -7,4 +7,6 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     int (*agentController)(node** agent, int numMoves, int numNodes),
     int (*dynamicKernel)(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents), int save);
 
+node** pathColour(node** graph, int numNodes, int (*agentController)(node**, int, int), int minColour, int maxColour, int save);
+
 #endif

--- a/include/graphutil.h
+++ b/include/graphutil.h
@@ -101,4 +101,8 @@ int* findColourFrequencies(node** graph, int numNodes, int maxColour);
 //will return the smallest colour if there is a tie
 int findMostCommonColourInGraph(node** graph, int numNodes, int maxColour);
 
+//returns a pointer to the node with the specified id in the graph
+//returns NULL if the provided id was not found
+node* findNodeWithIdInGraph(node** graph, int numNodes, int id);
+
 #endif

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -240,6 +240,8 @@ int main(int argc, char const *argv[]) {
 
         colouredGraph = agentColour(graph, &numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, save, colouringKernel, dynamicKernel, movementKernel);
 
+        // colouredGraph = pathColour(graph, numNodes, graph[0], graph[1], minColour, maxColour, save, colouringKernel);
+
         if(visualise) {
             autoRuns = 1;   //should only run once if viewing the graph
 
@@ -248,7 +250,6 @@ int main(int argc, char const *argv[]) {
 
             //enter interactive traversal mode
             printTraversalModeCommands();
-            //TODO: hard to see changes when you only see the non-recoloured graph
             while(traverseGraph(colouredGraph, numNodes, highestDegreeNode, 1) < 0) {
                 //run it again
                 colouredGraph = agentColour(colouredGraph, &numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, save, colouringKernel, dynamicKernel, movementKernel);

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -202,6 +202,7 @@ int main(int argc, char const *argv[]) {
 
             //enter interactive traversal mode
             printTraversalModeCommands();
+            //TODO: hard to see changes when you only see the non-recoloured graph
             while(traverseGraph(colouredGraph, numNodes, highestDegreeNode, 1) < 0) {
                 //run it again
                 // colouredGraph = agentColour(colouredGraph, &numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, agentController, dynamicKernel, save);

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -206,7 +206,7 @@ int main(int argc, char const *argv[]) {
             while(traverseGraph(colouredGraph, numNodes, highestDegreeNode, 1) < 0) {
                 //run it again
                 // colouredGraph = agentColour(colouredGraph, &numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, agentController, dynamicKernel, save);
-                node** traversedGraph = pathColour(colouredGraph, numNodes, colouredGraph[0], agentController, minColour, numNodes, 0);
+                node** traversedGraph = pathColour(colouredGraph, numNodes, colouredGraph[0], colouredGraph[1], agentController, minColour, numNodes, 0);
                 printf("new number of colours: %d\n", findNumColoursUsed(traversedGraph, numNodes, maxColour));
                 free(traversedGraph);
             }

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -204,7 +204,10 @@ int main(int argc, char const *argv[]) {
             printTraversalModeCommands();
             while(traverseGraph(colouredGraph, numNodes, highestDegreeNode, 1) < 0) {
                 //run it again
-                colouredGraph = agentColour(colouredGraph, &numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, agentController, dynamicKernel, save);
+                // colouredGraph = agentColour(colouredGraph, &numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, agentController, dynamicKernel, save);
+                node** traversedGraph = pathColour(colouredGraph, numNodes, colouredGraph[0], agentController, minColour, numNodes, 0);
+                printf("new number of colours: %d\n", findNumColoursUsed(traversedGraph, numNodes, maxColour));
+                free(traversedGraph);
             }
         }
 

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -100,3 +100,21 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
 
     return colouringGraph;
 }
+
+node** pathColour(node** graph, int numNodes, int (*agentController)(node**, int, int), int minColour, int maxColour, int save) {
+    node** colouringGraph = copyGraph(graph, numNodes);
+
+    //some sort of dynamic data structure
+    //probably a queue
+
+    //check the next node in the list
+    //try to colour it
+    //if numChanges > 1, add its neighbours to the queue
+    //remove the node from the queue
+
+    //repeat the process until the queue is empty
+
+    //print the new data, the number of updated nodes
+
+    //return the new coloured graph
+}

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -108,7 +108,7 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
 }
 
 node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* secondStartingNode, int minColour, int maxColour, int save,
-    int (*colouringKernel)(node**, int, int)
+    int (*colouringKernel)(node*, int)
 ) {
     node** colouringGraph = copyGraph(graph, numNodes);
 
@@ -129,7 +129,7 @@ node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* sec
 
     //some sort of dynamic data structure
     //probably a queue
-    node** colouringQueue = (node**)malloc(sizeof(node*) * numNodes);
+    node** colouringQueue = (node**)malloc(sizeof(node*) * (numNodes * numNodes));
 
     // add both starting nodes manually
     colouringQueue[0] = copyFirstStartingNode;
@@ -146,7 +146,7 @@ node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* sec
     while(queueLength > 0) {
         printf("queue length: %d\n", queueLength);
 
-        int numChanges = colouringKernel(&colouringQueue[0], 0, maxColour);
+        int numChanges = colouringKernel(colouringQueue[0], maxColour);
 
         if(numChanges > 0) {
             numUpdates++;

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -107,7 +107,9 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     return colouringGraph;
 }
 
-node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* secondStartingNode, int (*colouringKernel)(node**, int, int), int minColour, int maxColour, int save) {
+node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* secondStartingNode, int minColour, int maxColour, int save,
+    int (*colouringKernel)(node**, int, int)
+) {
     node** colouringGraph = copyGraph(graph, numNodes);
 
     //find the starting point in the new graph

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -101,22 +101,32 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     return colouringGraph;
 }
 
-node** pathColour(node** graph, int numNodes, node* startingNode, int (*agentController)(node**, int, int), int minColour, int maxColour, int save) {
+node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* secondStartingNode, int (*agentController)(node**, int, int), int minColour, int maxColour, int save) {
     node** colouringGraph = copyGraph(graph, numNodes);
 
     //find the starting point in the new graph
-    node* copyStartingNode = findNodeWithIdInGraph(colouringGraph, numNodes, startingNode->id);
+    node* copyFirstStartingNode = findNodeWithIdInGraph(colouringGraph, numNodes, firstStartingNode->id);
+    
+    if(copyFirstStartingNode == NULL) {
+        printf("failed to find first starting node in graph copy; aborting\n");
+        return NULL;
+    }
+    
+    node* copySecondStartingNode = findNodeWithIdInGraph(colouringGraph, numNodes, secondStartingNode->id);
 
-    if(copyStartingNode == NULL) {
-        printf("failed to find starting node in graph copy; aborting\n");
+    if(copyFirstStartingNode == NULL) {
+        printf("failed to find second starting node in graph copy; aborting\n");
         return NULL;
     }
 
     //some sort of dynamic data structure
     //probably a queue
     node** colouringQueue = (node**)malloc(sizeof(node*) * numNodes);
-    colouringQueue[0] = copyStartingNode;
-    int queueLength = 1;
+
+    // add both starting nodes manually
+    colouringQueue[0] = copyFirstStartingNode;
+    colouringQueue[1] = copySecondStartingNode;
+    int queueLength = 2;
 
     //check the next node in the list
     //try to colour it

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -107,7 +107,7 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     return colouringGraph;
 }
 
-node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* secondStartingNode, int (*agentController)(node**, int, int), int minColour, int maxColour, int save) {
+node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* secondStartingNode, int (*colouringKernel)(node**, int, int), int minColour, int maxColour, int save) {
     node** colouringGraph = copyGraph(graph, numNodes);
 
     //find the starting point in the new graph
@@ -144,7 +144,7 @@ node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* sec
     while(queueLength > 0) {
         printf("queue length: %d\n", queueLength);
 
-        int numChanges = agentController(&colouringQueue[0], 0, maxColour);
+        int numChanges = colouringKernel(&colouringQueue[0], 0, maxColour);
 
         if(numChanges > 0) {
             numUpdates++;

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -101,11 +101,21 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     return colouringGraph;
 }
 
-node** pathColour(node** graph, int numNodes, int (*agentController)(node**, int, int), int minColour, int maxColour, int save) {
+node** pathColour(node** graph, int numNodes, node* startingNode, int (*agentController)(node**, int, int), int minColour, int maxColour, int save) {
     node** colouringGraph = copyGraph(graph, numNodes);
+
+    //find the starting point in the new graph
+    node* copyStartingNode = findNodeWithIdInGraph(colouringGraph, numNodes, startingNode->id); 
+
+    if(copyStartingNode == NULL) {
+        printf("failed to find starting node in graph copy; aborting\n");
+        return NULL;
+    }
 
     //some sort of dynamic data structure
     //probably a queue
+    node** colouringQueue = (node**)malloc(sizeof(node*) * numNodes);
+    int queueLength = 0;
 
     //check the next node in the list
     //try to colour it
@@ -114,7 +124,10 @@ node** pathColour(node** graph, int numNodes, int (*agentController)(node**, int
 
     //repeat the process until the queue is empty
 
+    free(colouringQueue);
+
     //print the new data, the number of updated nodes
 
     //return the new coloured graph
+    return colouringGraph;
 }

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -105,7 +105,7 @@ node** pathColour(node** graph, int numNodes, node* startingNode, int (*agentCon
     node** colouringGraph = copyGraph(graph, numNodes);
 
     //find the starting point in the new graph
-    node* copyStartingNode = findNodeWithIdInGraph(colouringGraph, numNodes, startingNode->id); 
+    node* copyStartingNode = findNodeWithIdInGraph(colouringGraph, numNodes, startingNode->id);
 
     if(copyStartingNode == NULL) {
         printf("failed to find starting node in graph copy; aborting\n");

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -127,8 +127,7 @@ node** pathColour(node** graph, int numNodes, node* firstStartingNode, node* sec
         return NULL;
     }
 
-    //some sort of dynamic data structure
-    //probably a queue
+    //queue structure
     node** colouringQueue = (node**)malloc(sizeof(node*) * (numNodes * numNodes));
 
     // add both starting nodes manually

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -115,18 +115,47 @@ node** pathColour(node** graph, int numNodes, node* startingNode, int (*agentCon
     //some sort of dynamic data structure
     //probably a queue
     node** colouringQueue = (node**)malloc(sizeof(node*) * numNodes);
-    int queueLength = 0;
+    colouringQueue[0] = copyStartingNode;
+    int queueLength = 1;
 
     //check the next node in the list
     //try to colour it
     //if numChanges > 1, add its neighbours to the queue
     //remove the node from the queue
 
+    int numUpdates = 0;
+
+    while(queueLength > 0) {
+        printf("queue length: %d\n", queueLength);
+
+        int numChanges = agentController(&colouringQueue[0], 0, maxColour);
+
+        if(numChanges > 0) {
+            numUpdates++;
+
+            //add neighbours to queue if they are not already there
+            for(int nb = 0; nb < colouringQueue[0]->degree; nb++) {
+                for(int q = 0; q < queueLength; q++) {
+                    if(colouringQueue[q] == colouringQueue[0]->neighbours[nb]) continue;
+                }
+                colouringQueue[queueLength++] = colouringQueue[0]->neighbours[nb];
+            }
+        }
+
+        //shift queue up one
+        for(int n = 0; n < queueLength - 1; n++) {
+            colouringQueue[n] = colouringQueue[n + 1];
+        }
+
+        colouringQueue[--queueLength] = NULL;   //decrement queue length
+    }
+
     //repeat the process until the queue is empty
 
     free(colouringQueue);
 
     //print the new data, the number of updated nodes
+    printf("number of updates: %d\n\n", numUpdates);
 
     //return the new coloured graph
     return colouringGraph;

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -433,3 +433,13 @@ int findMostCommonColourInGraph(node** graph, int numNodes, int maxColour) {
 
     return mostCommonColour;
 }
+
+node* findNodeWithIdInGraph(node** graph, int numNodes, int id) {
+    for(int n = 0; n < numNodes; n++) {
+        if(graph[n]->id == id) {
+            return graph[n];
+        }
+    }
+
+    return NULL;
+}

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -42,14 +42,13 @@ node** copyGraph(node** graph, int numNodes) {
         memcpy(graphcpy[n], graph[n], sizeof(node));
     }
 
-    int* differentials = (int*)calloc(numNodes, sizeof(int));
-    if(numNodes - graph[numNodes - 1]->id != 0) {
+    int* differentials = (int*)calloc(graph[numNodes - 1]->id + 1, sizeof(int));
+    if(numNodes - (graph[numNodes - 1]->id + 1) != 0) {
         //graph indexes do not line up with ids, calculate differentials
-        int differential = 0;
         int nodesTraversed = 0;
 
         for(int n = 0; n < numNodes; n++) {
-            differentials[n] += graph[n]->id - nodesTraversed++;
+            differentials[graph[n]->id] = graph[n]->id - nodesTraversed++;
         }
     }
 

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -42,19 +42,28 @@ node** copyGraph(node** graph, int numNodes) {
         memcpy(graphcpy[n], graph[n], sizeof(node));
     }
 
-    //check if ids line up with indexes
-    int graphIsModified = graph[numNodes - 1]->id - numNodes != 0;
+    int* differentials = (int*)calloc(numNodes, sizeof(int));
+    if(numNodes - graph[numNodes - 1]->id != 0) {
+        //graph indexes do not line up with ids, calculate differentials
+        int differential = 0;
+        int nodesTraversed = 0;
+
+        for(int n = 0; n < numNodes; n++) {
+            differentials[n] += graph[n]->id - nodesTraversed++;
+        }
+    }
 
     //update the neighbours to point to the new array
     //do it after first loop so that all the nodes actually exist
     for(int n = 0; n < numNodes; n++) {
         graphcpy[n]->neighbours = (node**)malloc(sizeof(node*) * graphcpy[n]->degree);
         for(int nb = 0; nb < graphcpy[n]->degree; nb++) {
-            graphcpy[n]->neighbours[nb] = graphIsModified ? 
-                findNodeWithIdInGraph(graphcpy, numNodes, graph[n]->neighbours[nb]->id) : 
-                graphcpy[graph[n]->neighbours[nb]->id];
+            int neighbourId = graph[n]->neighbours[nb]->id;
+            graphcpy[n]->neighbours[nb] = graphcpy[neighbourId - differentials[neighbourId]];
         }
     }
+
+    free(differentials);
 
     return graphcpy;
 }

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -64,7 +64,9 @@ node** copyGraph(node** graph, int numNodes) {
         }
     }
 
-    free(differentials);
+    if(differentials != NULL) {
+        free(differentials);
+    }
 
     return graphcpy;
 }

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -42,9 +42,11 @@ node** copyGraph(node** graph, int numNodes) {
         memcpy(graphcpy[n], graph[n], sizeof(node));
     }
 
-    int* differentials = (int*)calloc(graph[numNodes - 1]->id + 1, sizeof(int));
+    int* differentials;
     if(numNodes - (graph[numNodes - 1]->id + 1) != 0) {
         //graph indexes do not line up with ids, calculate differentials
+
+        differentials = (int*)calloc(graph[numNodes - 1]->id + 1, sizeof(int));
         int nodesTraversed = 0;
 
         for(int n = 0; n < numNodes; n++) {

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -435,9 +435,7 @@ int findMostCommonColourInGraph(node** graph, int numNodes, int maxColour) {
 }
 
 node* findNodeWithIdInGraph(node** graph, int numNodes, int id) {
-    printf("numNodes: %d\n", numNodes);
     for(int n = 0; n < numNodes; n++) {
-        printf("%d ", n);
         if(graph[n]->id == id) {
             return graph[n];
         }

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -42,11 +42,10 @@ node** copyGraph(node** graph, int numNodes) {
         memcpy(graphcpy[n], graph[n], sizeof(node));
     }
 
-    int* differentials;
+    int* differentials = (int*)calloc(graph[numNodes - 1]->id + 1, sizeof(int));
     if(numNodes - (graph[numNodes - 1]->id + 1) != 0) {
         //graph indexes do not line up with ids, calculate differentials
 
-        differentials = (int*)calloc(graph[numNodes - 1]->id + 1, sizeof(int));
         int nodesTraversed = 0;
 
         for(int n = 0; n < numNodes; n++) {
@@ -64,9 +63,7 @@ node** copyGraph(node** graph, int numNodes) {
         }
     }
 
-    if(differentials != NULL) {
-        free(differentials);
-    }
+    free(differentials);
 
     return graphcpy;
 }

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -435,7 +435,9 @@ int findMostCommonColourInGraph(node** graph, int numNodes, int maxColour) {
 }
 
 node* findNodeWithIdInGraph(node** graph, int numNodes, int id) {
+    printf("numNodes: %d\n", numNodes);
     for(int n = 0; n < numNodes; n++) {
+        printf("%d ", n);
         if(graph[n]->id == id) {
             return graph[n];
         }

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -42,12 +42,17 @@ node** copyGraph(node** graph, int numNodes) {
         memcpy(graphcpy[n], graph[n], sizeof(node));
     }
 
+    //check if ids line up with indexes
+    int graphIsModified = graph[numNodes - 1]->id - numNodes != 0;
+
     //update the neighbours to point to the new array
     //do it after first loop so that all the nodes actually exist
     for(int n = 0; n < numNodes; n++) {
         graphcpy[n]->neighbours = (node**)malloc(sizeof(node*) * graphcpy[n]->degree);
         for(int nb = 0; nb < graphcpy[n]->degree; nb++) {
-            graphcpy[n]->neighbours[nb] = graphcpy[graph[n]->neighbours[nb]->id];
+            graphcpy[n]->neighbours[nb] = graphIsModified ? 
+                findNodeWithIdInGraph(graphcpy, numNodes, graph[n]->neighbours[nb]->id) : 
+                graphcpy[graph[n]->neighbours[nb]->id];
         }
     }
 


### PR DESCRIPTION
this is a cool new addition which implements a completely different type of colouring algorithm. it is not fully implemented into the main program, but it can be used to colour or (more appropriately) recolour the graph.

the concept is as follows:
- add two initial nodes to a queue (say, two nodes between which you have severed an edge)
- colour the first node in the queue
- if you made a change, add its neighbours to the queue
- pop the node from the queue
- repeat steps 2, 3 and 4 until the queue is empty

this process is a more distributed approach, since it fully applies the concept that a distributed system should only have to consider nodes which _need_ to be coloured, not all of the nodes in the graph.

this PR also includes an update to the `copyGraph` function. it extends the algorithm to allow for effective  and efficient copying of modified graphs (as in graphs that have had nodes removed). the copy function relies on the node ids in order to find the corresponding neighbour in the new graph, but if the graph nodes are modified, the ids will no longer line up with the array positions at some point in the graph. to fix this, we could use the new `findNodeWithIdInGraph` function, but this would mean doing a linear search on the graph for every neighbour; very slow. Instead, we precompute the differentials between id and position for each id in the graph, and use this to do a lookup operation. this enables very fast location of each node (and a very satisfying algorithm).


![](https://media1.tenor.com/m/rHAHMnDdMIAAAAAC/zoolander-will-ferrell.gif)
