### PR TITLE
bug fix: update number agents in main function

### DIFF
--- a/include/graphcolourer.h
+++ b/include/graphcolourer.h
@@ -3,7 +3,7 @@
 
 #include "node.h"
 
-node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, int save,
+node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int* numAgentsPtr, int numMoves, int minColour, int maxColour, int save,
     int (*colouringKernel)(node* agent, int numNodes),
     int (*dynamicKernel)(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents),
     node* (*movementKernel)(node* agent, int numMoves));

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -238,7 +238,7 @@ int main(int argc, char const *argv[]) {
             maxColour = findNumColoursUsed(benchmarkMinimumGraph, numNodes, numNodes + 1);
         }
 
-        colouredGraph = agentColour(graph, &numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, save, colouringKernel, dynamicKernel, movementKernel);
+        colouredGraph = agentColour(graph, &numNodes, maxIterations, &numAgents, numMoves, minColour, maxColour + 1, save, colouringKernel, dynamicKernel, movementKernel);
 
         // colouredGraph = pathColour(graph, numNodes, graph[0], graph[1], minColour, maxColour, save, colouringKernel);
 
@@ -252,7 +252,7 @@ int main(int argc, char const *argv[]) {
             printTraversalModeCommands();
             while(traverseGraph(colouredGraph, numNodes, highestDegreeNode, 1) < 0) {
                 //run it again
-                colouredGraph = agentColour(colouredGraph, &numNodes, maxIterations, numAgents, numMoves, minColour, maxColour + 1, save, colouringKernel, dynamicKernel, movementKernel);
+                colouredGraph = agentColour(colouredGraph, &numNodes, maxIterations, &numAgents, numMoves, minColour, maxColour + 1, save, colouringKernel, dynamicKernel, movementKernel);
             }
         }
 

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -105,7 +105,7 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int* numAg
         saveColouringData(maxColour, *numNodesPtr, numNodes, i, numAgents, finalNumColours, numConflicts, numMissedNodes, time);
     }
 
-    //update original value of numNodes
+    //update original value of numNodes and numAgents
     *numNodesPtr = numNodes;
     *numAgentsPtr = numAgents;
 

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -9,12 +9,13 @@
 #define AGENT_BREAK_LIMIT 10
 #define COLOUR_INCREASE_LIMIT 2
 
-node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAgents, int numMoves, int minColour, int maxColour, int save,
+node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int* numAgentsPtr, int numMoves, int minColour, int maxColour, int save,
     int (*colouringKernel)(node*, int),
     int (*dynamicKernel)(node***, int*, node*, node***, int*),
     node* (*movementKernel)(node*, int))
 {
     int numNodes = *numNodesPtr;
+    int numAgents = *numAgentsPtr;
 
     node** colouringGraph = copyGraph(graph, numNodes);
 
@@ -35,16 +36,22 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
     //start the iterations
     int i;
     for(i = 0; i < maxIterations; i++) {
+        printf("i: %d\n", i);
+        
         int numChanges = 0;
 
         //each agent makes changes to the graph
         for(int a = 0; a < numAgents; a++) {
+            printf("a: %d\n", a);
+
             numChanges += colouringKernel(agents[a], numColours);
 
             if(movementKernel != NULL) {
                 agents[a] = movementKernel(agents[a], numMoves);
             }
         }
+
+        printf("colouring kernel finished\n");
 
         if(dynamicKernel != NULL) {
             for(int a = 0; a < numAgents; a++) {
@@ -100,6 +107,7 @@ node** agentColour(node** graph, int* numNodesPtr, int maxIterations, int numAge
 
     //update original value of numNodes
     *numNodesPtr = numNodes;
+    *numAgentsPtr = numAgents;
 
     free(problemsAtIteration);
     free(agents);


### PR DESCRIPTION
this is a simple bug fix which accounts for the program being rerun from traversal mode after a dynamic kernel has been used to modify the number of nodes in the graph. essentially, the number of agents was not being updated, so although the number of agents selected was correct, the program would try and access a non-existent one. this PR changes this by passing a reference to the number of agents which can be updated. the dynamic kernel already updated the value, i just wasnt propogating it back as far as it needed to go.


![](https://media1.tenor.com/m/wrJlXp5CgvoAAAAC/inception.gif)
