### PR TITLE
threshold dynamic kernel

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ options:
                       e: possibly remove edge
                       n: possibly remove node
                       o: remove orphan nodes
+                      t: remove nodes based on a threshold
 -w [kernel]       set the movement kernel
                     sets the kernel used to move agents between nodes
                     options include:

--- a/help.txt
+++ b/help.txt
@@ -63,6 +63,7 @@ options:
                       e: possibly remove edge
                       n: possibly remove node
                       o: remove orphan nodes
+                      t: remove nodes based on a threshold
 -w [kernel]       set the movement kernel
                     sets the kernel used to move agents between nodes
                     options include:

--- a/include/dynamicKernels.h
+++ b/include/dynamicKernels.h
@@ -9,4 +9,6 @@ int possiblyRemoveNodeKernel(node*** graphReference, int* numNodes, node* agent,
 
 int removeOrphanNodesKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents);
 
+int removeNodeIfThereAreTooManyConflictsKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents);
+
 #endif

--- a/include/graphutil.h
+++ b/include/graphutil.h
@@ -71,6 +71,9 @@ node** findAllConflictingNodesInGraph(node** graph, int numNodes);
 //returns them in an array
 node** findConflictingNeighboursForNode(node* n);
 
+//returns the number of conflicts that node n is under
+int findNumberOfConflictsForNode(node* n);
+
 //does what it says on the tin; removes the edge between the node
 //and its neighbour
 int removeEdge(node* nodeReference, node* neighbour);

--- a/include/graphutil.h
+++ b/include/graphutil.h
@@ -94,7 +94,8 @@ int addEdgeBetweenNodes(node* nodeOne, node* nodeTwo);
 node* findNodeWithHighestDegree(node** graph, int numNodes);
 
 //this function modifies the provided list and list length in order to remove
-//the provided pointer from the list
+//the provided pointer from the list.
+//the list length is modified because there could be any number of items removed
 int removeAllInstancesOfNodePointerFromList(node*** nodeList, node* targetPointer, int* listLength);
 
 //returns a vector of numbers representing how many times each colour

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -169,6 +169,9 @@ int main(int argc, char const *argv[]) {
         case 'o':
             dynamicKernel = &removeOrphanNodesKernel;
             break;
+        case 't':
+            dynamicKernel = &removeNodeIfThereAreTooManyConflictsKernel;
+            break;
         case 'x':
             dynamicKernel = NULL;
             break;

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -125,8 +125,8 @@ int main(int argc, char const *argv[]) {
         }
 
 
-        int (*agentController) (node**, int, int) = &amongUsKernel;
-        int (*dynamicKernel) (node***, int*, node*, node***, int*) = NULL;
+        int (*agentController) (node**, int, int) = &minimumAgent;
+        int (*dynamicKernel) (node***, int*, node*, node***, int*) = &removeNodeIfThereAreTooManyConflictsKernel;
 
         //colour the graph
         benchmarkMinimumGraph = minimumColour(graph, numNodes);

--- a/src/colouringKernels.c
+++ b/src/colouringKernels.c
@@ -73,6 +73,11 @@ int minimumAgent(node** agentPointer, int numMoves, int maxColour) {
 
     free(coloursInLocality);
 
+    if(!agent->colour) {
+        agent->colour = max;
+        numChanges = 1;
+    }
+
     //move the agent
     for(int m = 0; m < numMoves; m++) {
         if(agent->degree == 0) {

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -32,3 +32,22 @@ int removeOrphanNodesKernel(node*** graphReference, int* numNodes, node* agent, 
 
     return 0;
 }
+
+
+int firstRound = 0; //counter to determine if we have already done a round of agents
+
+int removeNodeIfThereAreTooManyConflictsKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents) {
+    if(++firstRound > *numAgents) {
+        node** conflictingNeighbours = findConflictingNeighboursForNode(agent);
+        int numConflictingNeighbours = sizeof(conflictingNeighbours) / sizeof(node*);
+
+        if(numConflictingNeighbours > (agent->degree / 2)) {
+            removeNode(graphReference, *numNodes, agent);
+            *numNodes -= 1;
+
+            removeAllInstancesOfNodePointerFromList(agentsReference, agent, numAgents);
+        }
+    }
+    
+    return 0;
+}

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -33,20 +33,16 @@ int removeOrphanNodesKernel(node*** graphReference, int* numNodes, node* agent, 
     return 0;
 }
 
-
-int firstRound = 0; //counter to determine if we have already done a round of agents
-
 int removeNodeIfThereAreTooManyConflictsKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents) {
-    if(++firstRound > *numAgents) {
-        node** conflictingNeighbours = findConflictingNeighboursForNode(agent);
-        int numConflictingNeighbours = sizeof(conflictingNeighbours) / sizeof(node*);
+    int numConflictingNeighbours = findNumberOfConflictsForNode(agent);
 
-        if(numConflictingNeighbours > (agent->degree / 2)) {
-            removeNode(graphReference, *numNodes, agent);
-            *numNodes -= 1;
+    if(agent->colour && numConflictingNeighbours > (int)(agent->degree * 0.66)) {
+        printf("removed node %d\n", agent->id);
 
-            removeAllInstancesOfNodePointerFromList(agentsReference, agent, numAgents);
-        }
+        removeNode(graphReference, *numNodes, agent);
+        *numNodes -= 1;
+
+        removeAllInstancesOfNodePointerFromList(agentsReference, agent, numAgents);
     }
     
     return 0;

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -35,6 +35,7 @@ int removeOrphanNodesKernel(node*** graphReference, int* numNodes, node* agent, 
 
 int removeNodeIfThereAreTooManyConflictsKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents) {
     int numConflictingNeighbours = findNumberOfConflictsForNode(agent);
+    int numChanges = 0;
 
     if(agent->colour && numConflictingNeighbours > (int)(agent->degree * 0.66)) {
         printf("removed node %d\n", agent->id);
@@ -45,5 +46,5 @@ int removeNodeIfThereAreTooManyConflictsKernel(node*** graphReference, int* numN
         removeAllInstancesOfNodePointerFromList(agentsReference, agent, numAgents);
     }
     
-    return 0;
+    return numChanges;
 }

--- a/src/graphcolourer.c
+++ b/src/graphcolourer.c
@@ -34,7 +34,7 @@ node** agentColour(node** graph, int numNodes, int maxIterations, int numAgents,
 
         if(dynamicKernel != NULL) {
             for(int a = 0; a < numAgents; a++) {
-                dynamicKernel(&colouringGraph, &numNodes, agents[a], &agents, &numAgents);
+                numChanges += dynamicKernel(&colouringGraph, &numNodes, agents[a], &agents, &numAgents);
             }
         }
 

--- a/src/graphutil.c
+++ b/src/graphutil.c
@@ -263,7 +263,7 @@ node** findAllConflictingNodesInGraph(node** graph, int numNodes) {
         
         if(conflicts == NULL) continue;
 
-        int numConflicts = sizeof(conflicts) / sizeof(node*);
+        int numConflicts = findNumberOfConflictsForNode(graphCopy[i]);
 
         memcpy(conflictingNodes[totalNumConflictingNodes], conflicts, sizeof(node*) * numConflicts);
 
@@ -293,7 +293,19 @@ node** findConflictingNeighboursForNode(node* n) {
         return NULL;
     }
 
-    return (node**)realloc(conflictingNodes, numConflictingNodes * sizeof(numConflictingNodes));
+    return (node**)realloc(conflictingNodes, numConflictingNodes * sizeof(node*));
+}
+
+int findNumberOfConflictsForNode(node* n) {
+    int numConflictingNodes = 0;
+
+    for(int i = 0; i < n->degree; i++) {
+        if(n->colour == n->neighbours[i]->colour) {
+            numConflictingNodes++;
+        }
+    }
+
+    return numConflictingNodes;
 }
 
 int removeEdge(node* nodeReference, node* neighbourReference) {


### PR DESCRIPTION
this PR has been ready to go for a while, i just never got around to merging it. the idea with this kernel is that the agent should be capable of identifying "poor" constraints. it derives from a broader concept in evolutionary algorithms of moving between solutions and comparing constraints and conflicts to find the correct balance between good solutions and acceptable conflicts. the difference here is that we want to do this with the minimum amount of global knowledge, so the node only has information about its neighbours and we must find a way to identify the constraints we want to remove.

the kernel works fine, it is just awkward to change the constraint. could be worth looking at adding a new parameter which could allow us to pass values such as the chance that a node is removed from the graph in the other kernels and the threshold for this one. it can be used with the `t` option.

this PR also fixes the pointer size division mistake i had a while ago in the main function, but in a helper function which is only used in the `edgeChopperKernel`, which was a proof of concept that i have not used in any experiments.

finally, this allows dynamic kernels to contribute to changes in the graph. not 100% on this, but it conceptually makes sense for this kernel. i just return `0` from the other dynamic kernels at the moment anyway.


![](https://media1.tenor.com/m/nGhmXbXg0bAAAAAC/crossed-the-threshold-threshold.gif)
