### PR TITLE
dynamic kernel to reduce agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ options:
                       n: possibly remove node
                       o: remove orphan nodes
                       t: remove nodes based on a threshold
+                      a: possibly remove the agent, but not the node
 -w [kernel]       set the movement kernel
                     sets the kernel used to move agents between nodes
                     options include:

--- a/help.txt
+++ b/help.txt
@@ -64,6 +64,7 @@ options:
                       n: possibly remove node
                       o: remove orphan nodes
                       t: remove nodes based on a threshold
+                      a: possibly remove the agent, but not the node
 -w [kernel]       set the movement kernel
                     sets the kernel used to move agents between nodes
                     options include:

--- a/include/dynamicKernels.h
+++ b/include/dynamicKernels.h
@@ -20,4 +20,6 @@ int removeOrphanNodesKernel(node*** graphReference, int* numNodes, node* agent, 
 
 int removeNodeIfThereAreTooManyConflictsKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents);
 
+int reduceAgentsInGraphKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents);
+
 #endif

--- a/src/colouring.c
+++ b/src/colouring.c
@@ -172,6 +172,9 @@ int main(int argc, char const *argv[]) {
         case 't':
             dynamicKernel = &removeNodeIfThereAreTooManyConflictsKernel;
             break;
+        case 'a':
+            dynamicKernel = &reduceAgentsInGraphKernel;
+            break;
         case 'x':
             dynamicKernel = NULL;
             break;

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -48,3 +48,11 @@ int removeNodeIfThereAreTooManyConflictsKernel(node*** graphReference, int* numN
     
     return numChanges;
 }
+
+int reduceAgentsInGraphKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents) {
+    if(rand() & 1000 == 0) {
+        removeAllInstancesOfNodePointerFromList(agentsReference, agent, numAgents);
+    }
+
+    return 0;
+}

--- a/src/dynamicKernels.c
+++ b/src/dynamicKernels.c
@@ -50,7 +50,9 @@ int removeNodeIfThereAreTooManyConflictsKernel(node*** graphReference, int* numN
 }
 
 int reduceAgentsInGraphKernel(node*** graphReference, int* numNodes, node* agent, node*** agentsReference, int* numAgents) {
-    if(rand() & 1000 == 0) {
+    if(rand() % 100 == 0) {
+        printf("removing agent on node %d\n", agent->id);
+
         removeAllInstancesOfNodePointerFromList(agentsReference, agent, numAgents);
     }
 


### PR DESCRIPTION
this is a simple addition for an experiment where we incrementally reduce the number of agents in the graph over the course of the colouring. the expected outcome of this is that it becomes more difficult to achieve an effective colouring (more colours in the graph). could also be a more particular condition by which to remove the agents from the graph, but this is fine for the moment.

this kernel can be used via the `a` setting for `-d`.


![](https://media1.tenor.com/m/z0X6U7McZPcAAAAC/bye-im-out.gif)
