### PR TITLE
adding ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: configure
-      run: ./configure
     - name: build
       run: make compile_test
     - name: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,8 @@
 name: build and test
 
 on:
+  push:
+    branches: [ "*" ]
   pull_request:
     branches: [ "*" ]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: build and test
+
+on:
+  pull_request:
+    branches: [ "*" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: configure
+      run: ./configure
+    - name: build
+      run: make compile_test
+    - name: test
+      run: ./test_colouring

--- a/README.md
+++ b/README.md
@@ -160,3 +160,14 @@ options:
 ```sh
 ./colouring.exe -n 100 -p 0.5 -K dnx -v
 ```
+
+## Extending the code
+
+If you want, feel free to fork the repository in order to extend the code with new kernels in order to run new experiments. In order to add a new kernel, you simply need to do the following:
+
+1. navigate to the relevant file
+2. add the new function, following the established function signature
+3. add an option for it in the main function (`colouring.c`)
+4. add a test (optional)
+
+You can then use the kernel in your experiments

--- a/README.md
+++ b/README.md
@@ -36,10 +36,20 @@ This repository is the code for my **final year project**, dealing with **decent
 
 - clone the repo
 - run make
-```
+```sh
 make
 ```
 - alternatively manually compile the src files with whatever compiler you prefer
+
+## Running Tests
+
+- Run the tests to see that all of the logic works alright on your machine
+- Compile a test executable with
+```sh
+make compile_test
+``` 
+- run the test executable to run the tests
+
 
 ## Usage
 
@@ -127,22 +137,26 @@ options:
 
 #### Example Usage
 **colour a ring graph with 51 nodes and 10000 iterations max**
-```
+```sh
 ./colouring.exe -n 51 -g o -M 10000
 ```
 **colour a random graph which has a probability of 30% that each edge exists**
-```
+```sh
 ./colouring.exe -p 0.3
 ```
 **colour a bipartite graph with 2 nodes in the first set and 4 in the second**
-```
+```sh
 ./colouring.exe -g b -n 6 -s 2
 ```
-**colour a connected random graph with 1001 nodes, starting with 5 colours and working up to 50 max**
-```
+**colour a connected random graph with 1001 nodes, using at least 5 colours and at most 50 colours**
+```sh
 ./colouring.exe -n 1001 -p 1 -c 5 -C 50
 ```
 **colour a random graph with 300 nodes and 70% probability for each edge, using 50 agents that move twice on each turn, save the results and run it on 10 different graphs**
-```
+```sh
 ./colouring.exe -n 300 -p 0.7 -a 50 -m 2 -A 10 -S
+```
+**colour a random graph using the configuration of the decrementing kernel for colouring and the node removal kernel as a dynamic aspect, then view the graph in the interactive mode when finished**
+```sh
+./colouring.exe -n 100 -p 0.5 -K dnx -v
 ```

--- a/test/testUtil.c
+++ b/test/testUtil.c
@@ -1,4 +1,5 @@
 #include <stdlib.h>
+#include <stdio.h>
 #include "graphutil.h"
 #include "graphgenerator.h"
 #include "testUtil.h"
@@ -94,24 +95,12 @@ int testFreeGraph() {
 
     //free it
     freeGraph(g, NUM_NODES);
-    
-    for(int n = 0; n < NUM_NODES; n++) {
-        if(g[n] != NULL) {
-            return 1;
-        }
-    }
 
     //create a graph with no neighbours
     g = initialiseGraph(NUM_NODES, 0);
 
     //free it
     freeGraph(g, NUM_NODES);
-
-    for(int n = 0; n < NUM_NODES; n++) {
-        if(g[n] != NULL) {
-            return 1;
-        }
-    }
 
     return 0;
 }


### PR DESCRIPTION
this PR adds CI to the repository, so that the tests will be run automatically whenever a push or PR is made.

also, i have updated the README file to give more up to date example usages, explain how to run the tests manually and how to extend the code base with new kernels.

one other thing: i have removed the explicit `NULL` checks for the `freeGraph` test, since they did not work on linux. this is because technically the memory might not be `NULL`, it just is not assigned to the program, so while the pointer is not `NULL`, trying to access anything with it will crash the program. similar to before, the test now basically just tests that the function does not crash the program, which is good enough for freeing memory. if i come up with a platform independent means of testing this function more thoroughly, i will add it.

![](https://media1.tenor.com/m/ffoqwXOo_OUAAAAd/we-are-professionals-here-cat.gif)